### PR TITLE
Fix DynPlayerTextDrawGetTextSize height, two server crashes, and per-call allocations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,101 @@
+name: build
+
+on:
+  push:
+    branches: [ master, main ]
+    tags: [ 'v*' ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  linux:
+    name: Linux (x86)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # SA-MP plugins are loaded by a 32-bit server, so the .so must be x86.
+      - name: Install 32-bit toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib g++-multilib
+
+      - name: Configure
+        run: cmake -S src -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build --config Release -j
+
+      - name: Verify the artifact is 32-bit
+        run: |
+          file build/textdraw-streamer.so
+          file build/textdraw-streamer.so | grep -q 'ELF 32-bit'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: textdraw-streamer-linux
+          path: build/textdraw-streamer.so
+
+  windows:
+    name: Windows (x86)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -S src -B build -A Win32
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: textdraw-streamer-windows
+          path: build/Release/textdraw-streamer.dll
+
+  release:
+    name: Release
+    needs: [ linux, windows ]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: textdraw-streamer-linux
+          path: linux
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: textdraw-streamer-windows
+          path: windows
+
+      # The layout sampctl expects, per the "resources" block in pawn.json:
+      # the plugin under plugins/ and the include under pawno/include/.
+      - name: Package
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+
+          mkdir -p pkg/plugins pkg/pawno/include
+          cp textdraw-streamer.inc pkg/pawno/include/
+
+          cp linux/textdraw-streamer.so pkg/plugins/
+          (cd pkg && zip -r "../textdraw-streamer.${version}.linux.zip" plugins pawno)
+          rm pkg/plugins/textdraw-streamer.so
+
+          cp windows/textdraw-streamer.dll pkg/plugins/
+          (cd pkg && zip -r "../textdraw-streamer.${version}.windows.zip" plugins pawno)
+
+          ls -la textdraw-streamer.*.zip
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            textdraw-streamer.*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,10 @@ on:
 jobs:
   linux:
     name: Linux (x86)
-    runs-on: ubuntu-latest
+    # Pinned deliberately, not "latest": the plugin must load on older hosts
+    # (Debian 11/12, CentOS 7 era) that game panels still run. 22.04 ships
+    # glibc 2.35, so the .so cannot pick up a GLIBC_2.38+ requirement.
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -26,10 +29,26 @@ jobs:
       - name: Build
         run: cmake --build build --config Release -j
 
-      - name: Verify the artifact is 32-bit
+      - name: Verify the artifact is 32-bit and portable
         run: |
           file build/textdraw-streamer.so
           file build/textdraw-streamer.so | grep -q 'ELF 32-bit'
+
+          # Fail the build rather than ship a .so that will not load. 2.32 is
+          # comfortably below anything a current game host runs.
+          max_allowed="2.32"
+          required=$(objdump -T build/textdraw-streamer.so \
+            | grep -o 'GLIBC_[0-9]\+\.[0-9]\+' | sed 's/GLIBC_//' | sort -uV)
+
+          echo "glibc versions required:"
+          echo "$required" | sed 's/^/  /'
+
+          highest=$(echo "$required" | tail -1)
+          if [ "$(printf '%s\n%s\n' "$max_allowed" "$highest" | sort -V | tail -1)" != "$max_allowed" ]; then
+            echo "::error::Requires GLIBC_$highest, above the $max_allowed baseline."
+            exit 1
+          fi
+          echo "OK: highest requirement GLIBC_$highest <= $max_allowed"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,18 +10,38 @@ on:
 jobs:
   linux:
     name: Linux (x86)
-    # Pinned deliberately, not "latest": the plugin must load on older hosts
-    # (Debian 11/12, CentOS 7 era) that game panels still run. 22.04 ships
-    # glibc 2.35, so the .so cannot pick up a GLIBC_2.38+ requirement.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    # Built inside an old-glibc container rather than on the runner image.
+    # Whatever glibc builds the .so becomes its minimum requirement, and game
+    # hosts routinely run older distros than "ubuntu-latest" points at.
+    #
+    # Debian 11 ships glibc 2.31, which is deliberately *before* the 2.34
+    # libpthread/libdl/librt merge into libc. Building on anything 2.34+ makes
+    # sampgdk's dlopen/pthread calls demand GLIBC_2.34, which is what broke
+    # loading on real servers. 2.31 caps the requirement structurally.
+    container: debian:11
     steps:
-      - uses: actions/checkout@v4
-
-      # SA-MP plugins are loaded by a 32-bit server, so the .so must be x86.
-      - name: Install 32-bit toolchain
+      # Before checkout: the container is bare, and actions/checkout wants git.
+      - name: Install toolchain
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-multilib g++-multilib
+          set -e
+
+          # Bullseye's LTS window has ended, so its packages may have moved to
+          # archive.debian.org. Fall back rather than fail with a bare 404.
+          if ! apt-get update 2>/dev/null; then
+            echo "Primary mirrors unavailable; using archive.debian.org"
+            {
+              echo "deb http://archive.debian.org/debian bullseye main"
+              echo "deb http://archive.debian.org/debian-security bullseye-security main"
+            } > /etc/apt/sources.list
+            apt-get -o Acquire::Check-Valid-Until=false update
+          fi
+
+          apt-get install -y --no-install-recommends \
+            build-essential gcc-multilib g++-multilib \
+            cmake file binutils git ca-certificates
+
+      - uses: actions/checkout@v4
 
       - name: Configure
         run: cmake -S src -B build -DCMAKE_BUILD_TYPE=Release
@@ -34,9 +54,9 @@ jobs:
           file build/textdraw-streamer.so
           file build/textdraw-streamer.so | grep -q 'ELF 32-bit'
 
-          # Fail the build rather than ship a .so that will not load. 2.32 is
-          # comfortably below anything a current game host runs.
-          max_allowed="2.32"
+          # Fail the build rather than ship a .so that will not load. The
+          # container's own glibc (2.31) is the ceiling this can produce.
+          max_allowed="2.31"
           required=$(objdump -T build/textdraw-streamer.so \
             | grep -o 'GLIBC_[0-9]\+\.[0-9]\+' | sed 's/GLIBC_//' | sort -uV)
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 # Precompiled Headers
 *.gch
 *.pch
-
+/build_verify
 # Compiled Dynamic libraries
 *.so
 *.dylib

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,13 @@
 set(CMAKE_SUPPRESS_REGENERATION true)
 
-project(textdraw-streamer)
+# CMake 4 removed compatibility with a < 3.5 minimum, which "2.8" was.
+cmake_minimum_required(VERSION 3.10)
 
-cmake_minimum_required(VERSION 2.8)
+project(textdraw-streamer C CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 include(AMXConfig)
@@ -16,6 +21,13 @@ include_directories(
 
 add_definitions(-DSAMPGDK_AMALGAMATION)
 add_definitions(-DFMT_HEADER_ONLY)
+
+if(MSVC)
+  # service.cpp guards fmt::sprintf with try/catch so a malformed script format
+  # string cannot propagate out; that needs unwind semantics rather than relying
+  # on /EHsc arriving via CMake's default flags.
+  add_compile_options(/EHsc)
+endif()
 
 add_samp_plugin(textdraw-streamer
 	amxplugin.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,4 @@
-if (WIN32)
-    cmake_minimum_required(VERSION 3.12)
-else()
-    cmake_minimum_required(VERSION 3.10.2)
-endif()
+set(CMAKE_SUPPRESS_REGENERATION true)
 
 # CMake 4 removed compatibility with a < 3.5 minimum, which "2.8" was.
 cmake_minimum_required(VERSION 3.10)
@@ -17,34 +13,14 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(AMXConfig)
 include(AddSAMPPlugin)
 
-add_samp_plugin(textdraw-streamer
-    amxplugin.cpp
-    compilation_date.hpp
-    main.cpp
-    natives.hpp
-    natives_data.cpp
-    natives_global.cpp
-    natives_player.cpp
-    natives_plugin.cpp
-    plugin.h
-    plugin_version.hpp
-    plugincommon.h
-    sampgdk.cpp
-    sampgdk.hpp
-    service.cpp
-    service.hpp
-    slot_manager.cpp
-    slot_manager.hpp
-    textdraw_data.cpp
-    textdraw_data.hpp
-    textdraw-streamer.def
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/amx
+  ${CMAKE_CURRENT_SOURCE_DIR}/fmt
 )
 
-target_include_directories(textdraw-streamer PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/amx
-    ${CMAKE_CURRENT_SOURCE_DIR}/fmt
-)
+add_definitions(-DSAMPGDK_AMALGAMATION)
+add_definitions(-DFMT_HEADER_ONLY)
 
 if(MSVC)
   # service.cpp guards fmt::sprintf with try/catch so a malformed script format

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,14 +32,17 @@ endif()
 if(UNIX AND NOT APPLE)
   # Keep the .so loadable on older hosts than the one that built it.
   #
-  # glibc 2.38 introduced __isoc23_strtol / __isoc23_sscanf and, from GCC 13 on,
-  # the plain names are redirected to those versioned symbols. A plugin built on
-  # a current distro then refuses to load with:
+  # Two separate glibc traps, both decided by the *build* machine:
   #
-  #   version `GLIBC_2.38' not found (required by textdraw-streamer.so)
+  # 1. glibc 2.38 + GCC 13 redirect plain strtol/sscanf to __isoc23_* symbols
+  #    tagged GLIBC_2.38. Compiling the C sources as C17 keeps the old
+  #    unversioned names. This matters when building on a current distro; on an
+  #    older one it is simply a no-op.
   #
-  # Nothing here needs C23 semantics, so compile the C sources as C17. The
-  # symbols resolve to the long-standing unversioned ones instead.
+  # 2. glibc 2.34 merged libpthread/libdl/librt into libc, so sampgdk's
+  #    dlopen/pthread calls pick up GLIBC_2.34. No flag avoids that one -- it
+  #    requires building against an older glibc, which is why CI builds inside
+  #    a Debian 11 (glibc 2.31) container.
   add_compile_options($<$<COMPILE_LANGUAGE:C>:-std=gnu17>)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,20 @@ if(MSVC)
   add_compile_options(/EHsc)
 endif()
 
+if(UNIX AND NOT APPLE)
+  # Keep the .so loadable on older hosts than the one that built it.
+  #
+  # glibc 2.38 introduced __isoc23_strtol / __isoc23_sscanf and, from GCC 13 on,
+  # the plain names are redirected to those versioned symbols. A plugin built on
+  # a current distro then refuses to load with:
+  #
+  #   version `GLIBC_2.38' not found (required by textdraw-streamer.so)
+  #
+  # Nothing here needs C23 semantics, so compile the C sources as C17. The
+  # symbols resolve to the long-standing unversioned ones instead.
+  add_compile_options($<$<COMPILE_LANGUAGE:C>:-std=gnu17>)
+endif()
+
 add_samp_plugin(textdraw-streamer
 	amxplugin.cpp
 	compilation_date.hpp
@@ -51,3 +65,10 @@ add_samp_plugin(textdraw-streamer
 	textdraw_data.hpp
 	textdraw-streamer.def
 )
+
+if(UNIX AND NOT APPLE)
+  # libstdc++ and libgcc are the other moving target: static-link them so the
+  # host does not need a runtime as new as the build machine's either.
+  set_property(TARGET textdraw-streamer APPEND_STRING PROPERTY
+               LINK_FLAGS " -static-libstdc++ -static-libgcc")
+endif()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,35 @@ bool load = false;
 extern void *pAMXFunctions;
 std::set<AMX*> gAmx;
 
-PLUGIN_EXPORT unsigned int PLUGIN_CALL Supports() 
+static void PrintBanner(const char* state)
+{
+	sampgdk::logprintf("");
+	sampgdk::logprintf(" =================================");
+	sampgdk::logprintf(" |                               |");
+	sampgdk::logprintf(" |    textdraw-streamer v%d.%d.%d   |", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);
+	sampgdk::logprintf(" |            %-19s|", state);
+	sampgdk::logprintf(" |                               |");
+	sampgdk::logprintf(" |  Coding:                      |");
+	sampgdk::logprintf(" |                               |");
+	sampgdk::logprintf(" |  Burak (Nexor)                |");
+	sampgdk::logprintf(" |                               |");
+	sampgdk::logprintf(" |  Compiled:                    |");
+	sampgdk::logprintf(" |                               |");
+	sampgdk::logprintf(" |  %02d.%02d.%04d, %02d:%02d:%02d         |", BUILD_DAY, BUILD_MONTH, BUILD_YEAR, BUILD_HOUR, BUILD_MIN, BUILD_SEC);
+	sampgdk::logprintf(" |                               |");
+	sampgdk::logprintf(" |  Github:                      |");
+	sampgdk::logprintf(" |                               |");
+	sampgdk::logprintf(" |  github.com/nexquery          |");
+	sampgdk::logprintf(" |                               |");
+	sampgdk::logprintf(" |  Discord:                     |");
+	sampgdk::logprintf(" |                               |");
+	sampgdk::logprintf(" |  benburakya - Nexor#4730      |");
+	sampgdk::logprintf(" |                               |");
+	sampgdk::logprintf(" =================================");
+	sampgdk::logprintf("");
+}
+
+PLUGIN_EXPORT unsigned int PLUGIN_CALL Supports()
 {
 	return sampgdk::Supports() | SUPPORTS_AMX_NATIVES | SUPPORTS_PROCESS_TICK;
 }
@@ -35,33 +63,11 @@ PLUGIN_EXPORT bool PLUGIN_CALL Load(void **ppData)
 {
 	pAMXFunctions = ppData[PLUGIN_DATA_AMX_EXPORTS];
 	load = sampgdk::Load(ppData);
-	if (load)
-	{
-		sampgdk::logprintf("");
-		sampgdk::logprintf(" =================================");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |    textdraw-streamer v%d.%d.%d   |", MINOR, MAJOR, PATCH);
-		sampgdk::logprintf(" |            Loaded             |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  Coding:                      |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  Burak (Nexor)                |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  Compiled:                    |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  %02d.%02d.%04d, %02d:%02d:%02d         |", BUILD_DAY, BUILD_MONTH, BUILD_YEAR, BUILD_HOUR, BUILD_MIN, BUILD_SEC);
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  Github:                      |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  github.com/nexquery          |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  Discord:                     |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  benburakya - Nexor#4730      |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" =================================");
-		sampgdk::logprintf("");	
+
+	if (load) {
+		PrintBanner("Loaded");
 	}
+
 	return load;
 }
 
@@ -70,32 +76,9 @@ PLUGIN_EXPORT void PLUGIN_CALL Unload()
 	if (load)
 	{
 		GlobalText::Destroy();
-		PlayerText::Destroy(-1);
+		PlayerText::DestroyAll();
 
-		sampgdk::logprintf("");
-		sampgdk::logprintf(" =================================");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |    textdraw-streamer v%d.%d.%d   |", MINOR, MAJOR, PATCH);
-		sampgdk::logprintf(" |           Unloaded            |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  Coding:                      |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  Burak (Nexor)                |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  Compiled:                    |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  %02d.%02d.%04d, %02d:%02d:%02d         |", BUILD_DAY, BUILD_MONTH, BUILD_YEAR, BUILD_HOUR, BUILD_MIN, BUILD_SEC);
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  Github:                      |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  github.com/nexquery          |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  Discord:                     |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" |  benburakya - Nexor#4730      |");
-		sampgdk::logprintf(" |                               |");
-		sampgdk::logprintf(" =================================");
-		sampgdk::logprintf("");
+		PrintBanner("Unloaded");
 	}
 }
 
@@ -124,7 +107,7 @@ extern "C" const AMX_NATIVE_INFO NativeList[] =
 	{"DynamicTextDrawSetPreviewModel",					Natives::DynamicTextDrawSetPreviewModel},
 	{"DynamicTextDrawSetPreviewRot",					Natives::DynamicTextDrawSetPreviewRot},
 	{"DynamicTextDrawSetPreviewVehCol",					Natives::DynamicTextDrawSetPreviewVehicleColours},
-	
+
 	{"IsValidDynamicTextDraw",							Natives::IsValidDynamicTextDraw},
 	{"IsDynTextDrawVisibleForPlayer",					Natives::IsDynamicTextDrawVisibleForPlayer},
 	{"DynamicTextDrawGetString",						Natives::DynamicTextDrawGetString},
@@ -169,7 +152,7 @@ extern "C" const AMX_NATIVE_INFO NativeList[] =
 	{"DynamicPlayerTextDrawSetPrevMdl",					Natives::DynamicPlayerTextDrawSetPreviewModel},
 	{"DynamicPlayerTextDrawSetPrevRot",					Natives::DynamicPlayerTextDrawSetPreviewRot},
 	{"DynamicPlayerTextDrawPrevVehCol",					Natives::DynamicPlayerTextDrawSetPreviewVehicleColours},
-	
+
 	{"IsValidDynamicPlayerTextDraw",					Natives::IsValidDynamicPlayerTextDraw},
 	{"IsDynamicPlayerTextDrawVisible",					Natives::IsDynamicPlayerTextDrawVisible},
 	{"DynamicPlayerTextDrawGetString",					Natives::DynamicPlayerTextDrawGetString},
@@ -231,6 +214,10 @@ PLUGIN_EXPORT int PLUGIN_CALL AmxLoad(AMX *amx)
 
 PLUGIN_EXPORT int PLUGIN_CALL AmxUnload(AMX *amx)
 {
+	// The logger holds this AMX to resolve __file lazily; drop it before the
+	// script goes away so a later message cannot read freed memory.
+	Plugin_Settings::ClearContext(amx);
+
 	gAmx.erase(amx);
 	return AMX_ERR_NONE;
 }
@@ -242,9 +229,7 @@ PLUGIN_EXPORT void PLUGIN_CALL ProcessTick()
 
 PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerConnect(int playerid)
 {
-	// Baðlanan oyuncuyu listeye ekle
-	if (playerid >= 0 && playerid < MAX_PLAYERS)
-	{
+	if (playerid >= 0 && playerid < MAX_PLAYERS) {
 		GlobalText::PlayerList.insert(playerid);
 	}
 	return true;
@@ -252,116 +237,119 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerConnect(int playerid)
 
 PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerDisconnect(int playerid, int reason)
 {
-	// Baðlanan oyuncuda textdraw gözüküyor mu?
-	for (auto textList = GlobalText::gTextVisible.begin(); textList != GlobalText::gTextVisible.end(); textList++)
+	for (auto& entry : GlobalText::gTextVisible)
 	{
-		// Tüm textdrawlarda bu oyuncuyu ara
-		auto p = GlobalText::gTextVisible[textList->first].find(playerid);
-		if (p != GlobalText::gTextVisible[textList->first].end())
-		{
-			// Textdraw da gösteriliyorsa oyuncuyu kaldýr
-			GlobalText::gTextVisible[textList->first].erase(p);
+		// erase returns 0 when this player was not a viewer, so the lookup and the
+		// removal are one operation instead of find-then-erase per textdraw.
+		if (entry.second.erase(playerid) == 0) {
+			continue;
 		}
 
-		// Gösterilen textdraw da oyuncu kalmadýysa
-		if (GlobalText::gTextVisible[textList->first].empty())
+		// That was the last viewer, so hand the global slot back to the server.
+		if (entry.second.empty())
 		{
-			// Textdrawý sunucudan sil
-			auto t = GlobalText::gText->find(textList->first);
-			if (t != GlobalText::gText->end())
+			auto it = GlobalText::gText.find(entry.first);
+			if (it != GlobalText::gText.end())
 			{
-				if (t->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-				{
-					TextDrawDestroy(t->second->real_id);
-					t->second->real_id = INVALID_DYNAMIC_PLAYER_TEXTDRAW;
-				}
+				GlobalText::DestroyReal(it->second);
+				it->second.visible = false;
 			}
 		}
 	}
 
-	// Baðlanan oyuncuyu listeden kaldýr
 	GlobalText::PlayerList.erase(playerid);
 
-	// PlayerTextdraw havuzunu ve slot manageri temizle
+	// Frees the player's textdraw pool and resets their slot manager.
 	PlayerText::Destroy(playerid);
 	return true;
 }
 
 PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerClickTextDraw(int playerid, int clickedid)
 {
-	// ESC bastýysa
+	if (gAmx.empty()) {
+		return false;
+	}
+
+	int idx = 0;
+
+	// The escape key.
 	if (clickedid == INVALID_TEXT_DRAW)
 	{
-		int idx;
-		for (std::set<AMX*>::iterator p = gAmx.begin(); p != gAmx.end(); p++)
+		for (AMX* amx : gAmx)
 		{
-			if (!amx_FindPublic(*p, "OnCancelDynamicTextDraw", &idx))
+			if (!amx_FindPublic(amx, "OnCancelDynamicTextDraw", &idx))
 			{
-				amx_Push(*p, static_cast<cell>(playerid));
-				amx_Exec(*p, NULL, idx);
+				amx_Push(amx, static_cast<cell>(playerid));
+				amx_Exec(amx, NULL, idx);
 			}
-			
-			if (!amx_FindPublic(*p, "OnClickDynamicTextDraw", &idx))
+
+			if (!amx_FindPublic(amx, "OnClickDynamicTextDraw", &idx))
 			{
-				amx_Push(*p, static_cast<cell>(INVALID_TEXT_DRAW));
-				amx_Push(*p, static_cast<cell>(playerid));
-				amx_Exec(*p, NULL, idx);
+				amx_Push(amx, static_cast<cell>(INVALID_TEXT_DRAW));
+				amx_Push(amx, static_cast<cell>(playerid));
+				amx_Exec(amx, NULL, idx);
 			}
 		}
+
+		return false;
 	}
-	else
+
+	// Reverse index, rather than scanning every global textdraw for a real_id.
+	auto mapped = GlobalText::realToText.find(clickedid);
+	if (mapped == GlobalText::realToText.end()) {
+		return false;
+	}
+
+	for (AMX* amx : gAmx)
 	{
-		if (!gAmx.empty() && !GlobalText::gText->empty())
+		if (!amx_FindPublic(amx, "OnClickDynamicTextDraw", &idx))
 		{
-			for (std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->begin(); it != GlobalText::gText->end(); it++)
-			{
-				if (it->second->real_id == clickedid)
-				{
-					int idx;
-					for (std::set<AMX*>::iterator p = gAmx.begin(); p != gAmx.end(); p++)
-					{
-						if (!amx_FindPublic(*p, "OnClickDynamicTextDraw", &idx))
-						{
-							amx_Push(*p, static_cast<cell>(it->first));
-							amx_Push(*p, static_cast<cell>(playerid));
-							amx_Exec(*p, NULL, idx);
-						}
-					}
-					break;
-				}
-			}
+			amx_Push(amx, static_cast<cell>(mapped->second));
+			amx_Push(amx, static_cast<cell>(playerid));
+			amx_Exec(amx, NULL, idx);
 		}
 	}
+
 	return false;
 }
 
 PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerClickPlayerTextDraw(int playerid, int playertextid)
 {
-	if (!gAmx.empty() && PlayerText::pText[playerid] != nullptr && !PlayerText::pText[playerid]->empty())
+	if (gAmx.empty()) {
+		return false;
+	}
+
+	// Pool() does not insert, unlike the operator[] this replaces.
+	TextMap* pool = PlayerText::Pool(playerid);
+	if (pool == nullptr) {
+		return false;
+	}
+
+	for (const auto& entry : *pool)
 	{
-		for (auto it = PlayerText::pText[playerid]->begin(); it != PlayerText::pText[playerid]->end(); it++)
+		if (entry.second.real_id != playertextid) {
+			continue;
+		}
+
+		int idx = 0;
+		for (AMX* amx : gAmx)
 		{
-			if (it->second->real_id == playertextid)
+			if (!amx_FindPublic(amx, "OnClickDynamicPlayerTextDraw", &idx))
 			{
-				int idx;
-				for (std::set<AMX*>::iterator p = gAmx.begin(); p != gAmx.end(); p++)
-				{
-					if (!amx_FindPublic(*p, "OnClickDynamicPlayerTextDraw", &idx)) 
-					{
-						//	playerid, textid
-						//
-						//		|		|
-						//
-						//		0		1
-						//
-						amx_Push(*p, static_cast<cell>(it->first));	//	1
-						amx_Push(*p, static_cast<cell>(playerid));	//	0
-						amx_Exec(*p, NULL, idx);
-					}
-				}
-				break;
+				//	playerid, textid
+				//
+				//		|		|
+				//
+				//		0		1
+				//
+				amx_Push(amx, static_cast<cell>(entry.first));	//	1
+				amx_Push(amx, static_cast<cell>(playerid));		//	0
+				amx_Exec(amx, NULL, idx);
 			}
 		}
+
+		break;
 	}
+
 	return false;
 }

--- a/src/natives.hpp
+++ b/src/natives.hpp
@@ -18,10 +18,23 @@
 
 #include "sampgdk.hpp"
 
+// Exact arity check for the fixed-signature natives.
 #define CHECK_PARAMS(n) \
-	if (params[0] != (n * 4)) \
+	if (params[0] != static_cast<cell>((n) * sizeof(cell))) \
 	{ \
-		sampgdk::logprintf("%s: Expecting %d parameter(s), but found %d.", __func__, n, params[0] / sizeof(cell)); \
+		sampgdk::logprintf("%s: Expecting %d parameter(s), but found %d.", \
+			__func__, static_cast<int>(n), static_cast<int>(params[0] / sizeof(cell))); \
+		return 0; \
+	}
+
+// Minimum arity check for the variadic natives. These previously used
+// CHECK_PARAMS(params[0] / sizeof(cell)), which is always satisfied and so let a
+// call with too few arguments read past the end of the parameter array.
+#define CHECK_MIN_PARAMS(n) \
+	if (params[0] < static_cast<cell>((n) * sizeof(cell))) \
+	{ \
+		sampgdk::logprintf("%s: Expecting at least %d parameter(s), but found %d.", \
+			__func__, static_cast<int>(n), static_cast<int>(params[0] / sizeof(cell))); \
 		return 0; \
 	}
 

--- a/src/natives_data.cpp
+++ b/src/natives_data.cpp
@@ -18,55 +18,50 @@
 #include "natives.hpp"
 #include "service.hpp"
 
+#include <algorithm>
+
+namespace
+{
+	// Resolves either flavour of textdraw behind the type discriminator.
+	//
+	// The player branch previously did PlayerText::pText[playerid]->find(...) with
+	// no null check, which segfaulted the server for any player who had not yet
+	// created a player textdraw. PlayerText::Find performs the same guard sequence
+	// and logging as every other player native.
+	Text_Data* resolve(int type, int textid, int playerid, const char* funcs)
+	{
+		if (type == TDStreamer_Type::GLOBAL) {
+			return GlobalText::Find(textid, funcs);
+		}
+
+		if (type == TDStreamer_Type::PLAYER) {
+			return PlayerText::Find(playerid, textid, funcs);
+		}
+
+		Plugin_Settings::ILogger(LogType::INVALID_TYPE, funcs, INVALID_PLAYER_ID, INVALID_PLAYER_ID);
+		return nullptr;
+	}
+}
+
  //
  // native DynamicTextDraw_SetIntData(DYNAMIC_TEXTDRAW_TYPE:type, {Text, PlayerText}:textid, index, value, playerid = -1);
  //
 cell AMX_NATIVE_CALL Natives::DynamicTextDraw_SetIntData(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(5);
-	
-	int
-		type		= params[1],
-		textid		= params[2],
-		index		= params[3],
-		value		= params[4],
-		playerid	= params[5];
-	
-	if (type == TDStreamer_Type::GLOBAL)
-	{
-		auto it = GlobalText::gText->find(textid);
-		if (it == GlobalText::gText->end())
-		{
-			Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-			return 0;
-		}
 
-		std::map<int, int>* address = it->second->extra_id;
-		(*address)[index] = value;
-		return 1;
-	}
-	else if (type == TDStreamer_Type::PLAYER)
-	{
-		if (playerid >= 0 && playerid < MAX_PLAYERS)
-		{
-			auto it = PlayerText::pText[playerid]->find(textid);
-			if (it == PlayerText::pText[playerid]->end())
-			{
-				Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-				return 0;
-			}
+	Text_Data* data = resolve(
+		static_cast<int>(params[1]),
+		static_cast<int>(params[2]),
+		static_cast<int>(params[5]),
+		__func__);
 
-			std::map<int, int>* address = it->second->extra_id;
-			(*address)[index] = value;
-			return 1;
-		}
-	}
-	else
-	{
-		Plugin_Settings::ILogger(LogType::INVALID_TYPE, __func__, INVALID_PLAYER_ID, INVALID_PLAYER_ID);
+	if (data == nullptr) {
+		return 0;
 	}
 
-	return 0;
+	data->extra_id[static_cast<int>(params[3])] = static_cast<int>(params[4]);
+	return 1;
 }
 
 //
@@ -75,46 +70,20 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDraw_SetIntData(AMX* amx, cell* params)
 cell AMX_NATIVE_CALL Natives::DynamicTextDraw_GetIntData(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
-	
-	int
-		type		= params[1],
-		textid		= params[2],
-		index		= params[3],
-		playerid	= params[4];
-	
-	if (type == TDStreamer_Type::GLOBAL)
-	{
-		auto it = GlobalText::gText->find(textid);
-		if (it == GlobalText::gText->end())
-		{
-			Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-			return 0;
-		}
 
-		std::map<int, int>* address = (std::map<int, int>*)it->second->extra_id;
-		return (*address)[index];
-	}
-	else if (type == TDStreamer_Type::PLAYER)
-	{
-		if (playerid >= 0 && playerid < MAX_PLAYERS)
-		{
-			auto it = PlayerText::pText[playerid]->find(textid);
-			if (it == PlayerText::pText[playerid]->end())
-			{
-				Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-				return 0;
-			}
+	Text_Data* data = resolve(
+		static_cast<int>(params[1]),
+		static_cast<int>(params[2]),
+		static_cast<int>(params[4]),
+		__func__);
 
-			std::map<int, int>* address = it->second->extra_id;
-			return (*address)[index];
-		}
-	}
-	else
-	{
-		Plugin_Settings::ILogger(LogType::INVALID_TYPE, __func__, INVALID_PLAYER_ID, INVALID_PLAYER_ID);
+	if (data == nullptr) {
+		return 0;
 	}
 
-	return 0;
+	// Deliberately does not insert on a miss, unlike the operator[] this replaces.
+	auto it = data->extra_id.find(static_cast<int>(params[3]));
+	return (it == data->extra_id.end()) ? 0 : static_cast<cell>(it->second);
 }
 
 //
@@ -123,49 +92,19 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDraw_GetIntData(AMX* amx, cell* params)
 cell AMX_NATIVE_CALL Natives::DynamicTextDraw_ClearIntData(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(3);
-	
-	int
-		type		= params[1],
-		textid		= params[2],
-		playerid	= params[3];
 
-	if (type == TDStreamer_Type::GLOBAL)
-	{
-		auto it = GlobalText::gText->find(textid);
-		if (it == GlobalText::gText->end())
-		{
-			Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-			return 0;
-		}
+	Text_Data* data = resolve(
+		static_cast<int>(params[1]),
+		static_cast<int>(params[2]),
+		static_cast<int>(params[3]),
+		__func__);
 
-		delete it->second->extra_id;
-		std::map<int, int>* address = new std::map<int, int>();
-		it->second->extra_id = address;
-		return 1;
-	}
-	else if (type == TDStreamer_Type::PLAYER)
-	{
-		if (playerid >= 0 && playerid < MAX_PLAYERS)
-		{
-			auto it = PlayerText::pText[playerid]->find(textid);
-			if (it == PlayerText::pText[playerid]->end())
-			{
-				Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-				return 0;
-			}
-
-			delete it->second->extra_id;
-			std::map<int, int>* address = new std::map<int, int>();
-			it->second->extra_id = address;
-			return 1;
-		}
-	}
-	else
-	{
-		Plugin_Settings::ILogger(LogType::INVALID_TYPE, __func__, INVALID_PLAYER_ID, INVALID_PLAYER_ID);
+	if (data == nullptr) {
+		return 0;
 	}
 
-	return 0;
+	data->extra_id.clear();
+	return 1;
 }
 
 //
@@ -175,44 +114,18 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDraw_SetFloatData(AMX* amx, cell* param
 {
 	CHECK_PARAMS(4);
 
-	int		type		= params[1];
-	int		textid		= params[2];
-	float	value		= amx_ctof(params[3]);
-	int		playerid	= params[4];
+	Text_Data* data = resolve(
+		static_cast<int>(params[1]),
+		static_cast<int>(params[2]),
+		static_cast<int>(params[4]),
+		__func__);
 
-	if (type == TDStreamer_Type::GLOBAL)
-	{
-		auto it = GlobalText::gText->find(textid);
-		if (it == GlobalText::gText->end())
-		{
-			Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-			return 0;
-		}
-
-		it->second->float_data = value;
-		return 1;
-	}
-	else if (type == TDStreamer_Type::PLAYER)
-	{
-		if (playerid >= 0 && playerid < MAX_PLAYERS)
-		{
-			auto it = PlayerText::pText[playerid]->find(textid);
-			if (it == PlayerText::pText[playerid]->end())
-			{
-				Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-				return 0;
-			}
-
-			it->second->float_data = value;
-			return 1;
-		}
-	}
-	else
-	{
-		Plugin_Settings::ILogger(LogType::INVALID_TYPE, __func__, INVALID_PLAYER_ID, INVALID_PLAYER_ID);
+	if (data == nullptr) {
+		return 0;
 	}
 
-	return 0;
+	data->float_data = amx_ctof(params[3]);
+	return 1;
 }
 
 //
@@ -222,38 +135,17 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDraw_GetFloatData(AMX* amx, cell* param
 {
 	CHECK_PARAMS(3);
 
-	int		type		= params[1];
-	int		textid		= params[2];
-	int		playerid	= params[3];
-	float	value		= 0.0;
+	Text_Data* data = resolve(
+		static_cast<int>(params[1]),
+		static_cast<int>(params[2]),
+		static_cast<int>(params[3]),
+		__func__);
 
-	if (type == TDStreamer_Type::GLOBAL)
-	{
-		auto it = GlobalText::gText->find(textid);
-		if (it == GlobalText::gText->end())
-		{
-			Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-			return amx_ftoc(value);
-		}
-		return amx_ftoc(it->second->float_data);
+	float value = 0.0f;
+	if (data != nullptr) {
+		value = data->float_data;
 	}
-	else if (type == TDStreamer_Type::PLAYER)
-	{
-		if (playerid >= 0 && playerid < MAX_PLAYERS)
-		{
-			auto it = PlayerText::pText[playerid]->find(textid);
-			if (it == PlayerText::pText[playerid]->end())
-			{
-				Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-				return amx_ftoc(value);
-			}
-			return amx_ftoc(it->second->float_data);
-		}
-	}
-	else
-	{
-		Plugin_Settings::ILogger(LogType::INVALID_TYPE, __func__, INVALID_PLAYER_ID, INVALID_PLAYER_ID);
-	}
+
 	return amx_ftoc(value);
 }
 
@@ -264,56 +156,29 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDraw_SetArrayData(AMX* amx, cell* param
 {
 	CHECK_PARAMS(5);
 
-	int	type		= params[1];
-	int	textid		= params[2];
-	int	playerid	= params[4];
+	Text_Data* data = resolve(
+		static_cast<int>(params[1]),
+		static_cast<int>(params[2]),
+		static_cast<int>(params[4]),
+		__func__);
 
-	if (type == TDStreamer_Type::GLOBAL)
-	{
-		auto it = GlobalText::gText->find(textid);
-		if (it == GlobalText::gText->end())
-		{
-			Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-			return 0;
-		}
+	if (data == nullptr) {
+		return 0;
+	}
 
-		it->second->array_data->clear();
-
-		cell* array = NULL;
-		amx_GetAddr(amx, params[3], &array);
-		for (int i = 0, j = static_cast<int>(params[5]); i != j; ++i)
-		{
-			it->second->array_data->push_back(static_cast<int>(array[i]));
-		}
+	const int count = static_cast<int>(params[5]);
+	if (count <= 0) {
+		data->array_data.clear();
 		return 1;
 	}
-	else if (type == TDStreamer_Type::PLAYER)
-	{
-		if (playerid >= 0 && playerid < MAX_PLAYERS)
-		{
-			auto it = PlayerText::pText[playerid]->find(textid);
-			if (it == PlayerText::pText[playerid]->end())
-			{
-				Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-				return 0;
-			}
-			
-			it->second->array_data->clear();
 
-			cell* array = NULL;
-			amx_GetAddr(amx, params[3], &array);
-			for (int i = 0, j = static_cast<int>(params[5]); i != j; ++i)
-			{
-				it->second->array_data->push_back(static_cast<int>(array[i]));
-			}
-			return 1;
-		}
+	cell* array = nullptr;
+	if (amx_GetAddr(amx, params[3], &array) != AMX_ERR_NONE || array == nullptr) {
+		return 0;
 	}
-	else
-	{
-		Plugin_Settings::ILogger(LogType::INVALID_TYPE, __func__, INVALID_PLAYER_ID, INVALID_PLAYER_ID);
-	}
-	return 0;
+
+	data->array_data.assign(array, array + count);
+	return 1;
 }
 
 //
@@ -323,64 +188,32 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDraw_GetArrayData(AMX* amx, cell* param
 {
 	CHECK_PARAMS(5);
 
-	int	type = params[1];
-	int	textid = params[2];
-	int	playerid = params[4];
+	Text_Data* data = resolve(
+		static_cast<int>(params[1]),
+		static_cast<int>(params[2]),
+		static_cast<int>(params[4]),
+		__func__);
 
-	if (type == TDStreamer_Type::GLOBAL)
-	{
-		auto it = GlobalText::gText->find(textid);
-		if (it == GlobalText::gText->end())
-		{
-			Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-			return 0;
-		}
-
-		int index = 0;
-		cell* array = NULL;
-		amx_GetAddr(amx, params[3], &array);
-
-		for (std::vector<int>::const_iterator data = it->second->array_data->begin(); data != it->second->array_data->end(); ++data)
-		{
-			if (index == static_cast<int>(params[5]))
-			{
-				break;
-			}
-			array[index++] = static_cast<cell>(*data);
-		}
-		return 1;
+	if (data == nullptr) {
+		return 0;
 	}
-	else if (type == TDStreamer_Type::PLAYER)
-	{
-		if (playerid >= 0 && playerid < MAX_PLAYERS)
-		{
-			auto it = PlayerText::pText[playerid]->find(textid);
-			if (it == PlayerText::pText[playerid]->end())
-			{
-				Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-				return 0;
-			}
 
-			int index = 0;
-			cell* array = NULL;
-			amx_GetAddr(amx, params[3], &array);
+	const int capacity = static_cast<int>(params[5]);
+	if (capacity <= 0) {
+		return 0;
+	}
 
-			for (std::vector<int>::const_iterator data = it->second->array_data->begin(); data != it->second->array_data->end(); ++data)
-			{
-				if (index == static_cast<int>(params[5]))
-				{
-					break;
-				}
-				array[index++] = static_cast<cell>(*data);
-			}
-			return 1;
-		}
+	cell* array = nullptr;
+	if (amx_GetAddr(amx, params[3], &array) != AMX_ERR_NONE || array == nullptr) {
+		return 0;
 	}
-	else
-	{
-		Plugin_Settings::ILogger(LogType::INVALID_TYPE, __func__, INVALID_PLAYER_ID, INVALID_PLAYER_ID);
+
+	const size_t limit = (std::min)(static_cast<size_t>(capacity), data->array_data.size());
+	for (size_t i = 0; i < limit; ++i) {
+		array[i] = static_cast<cell>(data->array_data[i]);
 	}
-	return 0;
+
+	return 1;
 }
 
 //
@@ -390,44 +223,16 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDraw_ClearArrayData(AMX* amx, cell* par
 {
 	CHECK_PARAMS(3);
 
-	int	type = params[1];
-	int	textid = params[2];
-	int	playerid = params[3];
+	Text_Data* data = resolve(
+		static_cast<int>(params[1]),
+		static_cast<int>(params[2]),
+		static_cast<int>(params[3]),
+		__func__);
 
-	if (type == TDStreamer_Type::GLOBAL)
-	{
-		auto it = GlobalText::gText->find(textid);
-		if (it == GlobalText::gText->end())
-		{
-			Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-			return 0;
-		}
+	if (data == nullptr) {
+		return 0;
+	}
 
-		delete it->second->array_data;
-		std::vector<int>* arr = new std::vector<int>();
-		it->second->array_data = arr;
-		return 1;
-	}
-	else if (type == TDStreamer_Type::PLAYER)
-	{
-		if (playerid >= 0 && playerid < MAX_PLAYERS)
-		{
-			auto it = PlayerText::pText[playerid]->find(textid);
-			if (it == PlayerText::pText[playerid]->end())
-			{
-				Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-				return 0;
-			}
-
-			delete it->second->array_data;
-			std::vector<int>* arr = new std::vector<int>();
-			it->second->array_data = arr;
-			return 1;
-		}
-	}
-	else
-	{
-		Plugin_Settings::ILogger(LogType::INVALID_TYPE, __func__, INVALID_PLAYER_ID, INVALID_PLAYER_ID);
-	}
-	return 0;
+	data->array_data.clear();
+	return 1;
 }

--- a/src/natives_global.cpp
+++ b/src/natives_global.cpp
@@ -24,52 +24,17 @@
  //
 cell AMX_NATIVE_CALL Natives::CreateDynamicTextDraw(AMX* amx, cell* params)
 {
-	// Parametreler
-	CHECK_PARAMS(params[0] / sizeof(cell));
+	CHECK_MIN_PARAMS(3);
 
-	// Textdraw kimliði oluþtur
-	int auto_increment = slot_manager_global::get_id();
+	const int textid = slot_manager_global::get_id();
 
-	// Extra ID oluþtur
-	std::map<int, int>* map = new std::map<int, int>();
+	Text_Data& data = GlobalText::gText[textid];
+	data = Text_Data();
+	data.create_x = amx_ctof(params[1]);
+	data.create_y = amx_ctof(params[2]);
+	data.text = service::formattedString(amx, params, 3, 4);
 
-	// Array Data'yý oluþtur
-	std::vector<int>* arr = new std::vector<int>();
-
-	// Textdraw verilerini oluþtur
-	Text_Data* data			= new Text_Data();
-	data->real_id			= -1;
-	data->create_x			= amx_ctof(params[1]);
-	data->create_y			= amx_ctof(params[2]);
-	data->text				= service::formattedString(amx, params, 3, 4);
-	data->lettersize_x		= 0.0;
-	data->lettersize_y		= 0.0;
-	data->textsize_x		= 0.0;
-	data->textsize_y		= 0.0;
-	data->alignment			= 1;
-	data->color				= -2;
-	data->usebox			= 0;
-	data->boxcolor			= -2;
-	data->shadow			= 2;
-	data->outline			= 0;
-	data->backgroundcolor	= -2;
-	data->font				= 1;
-	data->proportional		= 1;
-	data->selectable		= 0;
-	data->modelindex		= 0;
-	data->fRotX				= 0.0;
-	data->fRotY				= 0.0;
-	data->fRotZ				= 0.0;
-	data->fZoom				= 1.0;
-	data->veh_col1			= -2;
-	data->veh_col2			= -2;
-	data->extra_id			= map;
-	data->float_data		= 0.0;
-	data->array_data		= arr;
-
-	// Verileri kaydet
-	GlobalText::gText->emplace(auto_increment, data);
-	return static_cast<cell>(auto_increment);
+	return static_cast<cell>(textid);
 }
 
 //
@@ -78,42 +43,24 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicTextDraw(AMX* amx, cell* params)
 cell AMX_NATIVE_CALL Natives::DestroyDynamicTextDraw(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(3);
-	
-	int 
-		textid = static_cast<int>(params[1]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) 
-	{
-		TextDrawDestroy(it->second->real_id), it->second->real_id = INVALID_DYNAMIC_PLAYER_TEXTDRAW;
-	}
+	GlobalText::DestroyReal(*data);
 
-	// Auto Increment
 	slot_manager_global::remove_id(textid);
 
-	// Visible
-	GlobalText::gTextVisible[textid].clear();
+	// Erase the outer entry too: clearing only the inner set left one empty set
+	// behind per textdraw ever created.
+	GlobalText::gTextVisible.erase(textid);
+	GlobalText::gText.erase(textid);
 
-	// Extra Id
-	delete it->second->extra_id;
-
-	// Array Data
-	delete it->second->array_data;
-
-	// Text data
-	delete it->second;
-
-	// Iterator
-	GlobalText::gText->erase(it);
 	return 1;
 }
 
@@ -124,29 +71,19 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawLetterSize(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(5);
 
-	int 
-		textid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	float
-		width = amx_ctof(params[2]),
-		height = amx_ctof(params[3]);
-
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->lettersize_x = width;
-	it->second->lettersize_y = height;
+	data->lettersize_x = amx_ctof(params[2]);
+	data->lettersize_y = amx_ctof(params[3]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawLetterSize(it->second->real_id, it->second->lettersize_x, it->second->lettersize_y);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawLetterSize(data->real_id, data->lettersize_x, data->lettersize_y);
 	}
 
 	return 1;
@@ -159,29 +96,19 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawTextSize(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(5);
 
-	int
-		textid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	float
-		width = amx_ctof(params[2]),
-		height = amx_ctof(params[3]);
-
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->textsize_x = width;
-	it->second->textsize_y = height;
+	data->textsize_x = amx_ctof(params[2]);
+	data->textsize_y = amx_ctof(params[3]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawTextSize(it->second->real_id, it->second->textsize_x, it->second->textsize_y);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawTextSize(data->real_id, data->textsize_x, data->textsize_y);
 	}
 
 	return 1;
@@ -194,25 +121,18 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawAlignment(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
 
-	int
-		textid = static_cast<int>(params[1]),
-		alignment = static_cast<int>(params[2]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->alignment = static_cast<int>(params[2]);
+	data->alignment = static_cast<int>(params[2]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawAlignment(it->second->real_id, it->second->alignment);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawAlignment(data->real_id, data->alignment);
 	}
 
 	return 1;
@@ -225,25 +145,18 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawColour(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
 
-	int
-		textid = static_cast<int>(params[1]),
-		textColour = static_cast<int>(params[2]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->color = textColour;
+	data->color = static_cast<int>(params[2]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawColor(it->second->real_id, it->second->color);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawColor(data->real_id, data->color);
 	}
 
 	return 1;
@@ -256,25 +169,18 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawUseBox(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
 
-	int
-		textid = static_cast<int>(params[1]),
-		enableBox = static_cast<int>(params[2]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->usebox = enableBox;
+	data->usebox = static_cast<int>(params[2]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawUseBox(it->second->real_id, it->second->usebox);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawUseBox(data->real_id, data->usebox);
 	}
 
 	return 1;
@@ -287,27 +193,20 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawBoxColour(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
 
-	int
-		textid = static_cast<int>(params[1]),
-		boxColour = static_cast<int>(params[2]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->boxcolor = boxColour;
+	data->boxcolor = static_cast<int>(params[2]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawBoxColor(it->second->real_id, it->second->boxcolor);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawBoxColor(data->real_id, data->boxcolor);
 	}
-	
+
 	return 1;
 }
 
@@ -318,25 +217,18 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawSetShadow(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
 
-	int
-		textid = static_cast<int>(params[1]),
-		shadowSize = static_cast<int>(params[2]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->shadow = shadowSize;
+	data->shadow = static_cast<int>(params[2]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawSetShadow(it->second->real_id, it->second->shadow);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawSetShadow(data->real_id, data->shadow);
 	}
 
 	return 1;
@@ -349,25 +241,18 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawSetOutline(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
 
-	int
-		textid = static_cast<int>(params[1]),
-		outlineSize = static_cast<int>(params[2]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->outline = outlineSize;
+	data->outline = static_cast<int>(params[2]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawSetOutline(it->second->real_id, it->second->outline);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawSetOutline(data->real_id, data->outline);
 	}
 
 	return 1;
@@ -380,25 +265,18 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawBackgroundColour(AMX* amx, cell* pa
 {
 	CHECK_PARAMS(4);
 
-	int
-		textid = static_cast<int>(params[1]),
-		backgroundColour = static_cast<int>(params[2]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->backgroundcolor = backgroundColour;
+	data->backgroundcolor = static_cast<int>(params[2]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawBackgroundColor(it->second->real_id, it->second->backgroundcolor);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawBackgroundColor(data->real_id, data->backgroundcolor);
 	}
 
 	return 1;
@@ -411,25 +289,18 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawFont(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
 
-	int
-		textid = static_cast<int>(params[1]),
-		font = static_cast<int>(params[2]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->font = font;
+	data->font = static_cast<int>(params[2]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawFont(it->second->real_id, it->second->font);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawFont(data->real_id, data->font);
 	}
 
 	return 1;
@@ -442,25 +313,18 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawSetProportional(AMX* amx, cell* par
 {
 	CHECK_PARAMS(4);
 
-	int
-		textid = static_cast<int>(params[1]),
-		proportional = static_cast<int>(params[2]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->proportional = proportional;
+	data->proportional = static_cast<int>(params[2]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawSetProportional(it->second->real_id, it->second->proportional);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawSetProportional(data->real_id, data->proportional);
 	}
 
 	return 1;
@@ -473,25 +337,18 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawSetSelectable(AMX* amx, cell* param
 {
 	CHECK_PARAMS(4);
 
-	int
-		textid = static_cast<int>(params[1]),
-		selectable = static_cast<int>(params[2]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->selectable = selectable;
+	data->selectable = static_cast<int>(params[2]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawSetSelectable(it->second->real_id, it->second->selectable);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawSetSelectable(data->real_id, data->selectable);
 	}
 
 	return 1;
@@ -503,44 +360,31 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawSetSelectable(AMX* amx, cell* param
 cell AMX_NATIVE_CALL Natives::DynamicTextDrawShowForPlayer(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
-	
-	int 
-		playerid = static_cast<int>(params[1]), 
-		textid = static_cast<int>(params[2]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	// Gösterilecek oyuncu sunucuda yoksa alt fonksiyonlarý çalýþtýrma
 	if (!IsPlayerConnected(playerid)) {
 		return 0;
 	}
 
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (GlobalText::gTextVisible[textid].empty())
+	// Reload is a no-op when the textdraw is already allocated server-side.
+	if (!GlobalText::Reload(textid, *data))
 	{
-		GlobalText::Reload(it);
-		if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-		{
-			GlobalText::gTextVisible[textid][playerid] = true;
-			TextDrawShowForPlayer(playerid, it->second->real_id);
-		}
-	}
-	else
-	{
-		GlobalText::gTextVisible[textid][playerid] = true;
-		if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-		{
-			TextDrawShowForPlayer(playerid, it->second->real_id);
-		}
+		Plugin_Settings::ILogger(LogType::SHOW_LIMIT_GLOBAL, __func__, playerid, textid);
+		return 0;
 	}
 
+	GlobalText::gTextVisible[textid].insert(playerid);
+	data->visible = true;
+
+	TextDrawShowForPlayer(playerid, data->real_id);
 	return 1;
 }
 
@@ -550,34 +394,32 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawShowForPlayer(AMX* amx, cell* param
 cell AMX_NATIVE_CALL Natives::DynamicTextDrawHideForPlayer(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
-	
-	int 
-		playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	std::map<int, bool>::iterator p = GlobalText::gTextVisible[textid].find(playerid);
+	std::unordered_set<int>& viewers = GlobalText::gTextVisible[textid];
+	viewers.erase(playerid);
 
-	if (p != GlobalText::gTextVisible[textid].end()) {
-		GlobalText::gTextVisible[textid].erase(p);
-	}
-
-	if (!GlobalText::gTextVisible[textid].empty())
+	if (!viewers.empty())
 	{
-		TextDrawHideForPlayer(playerid, it->second->real_id);
+		if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+			TextDrawHideForPlayer(playerid, data->real_id);
+		}
 	}
 	else
 	{
-		TextDrawDestroy(it->second->real_id), it->second->real_id = INVALID_DYNAMIC_PLAYER_TEXTDRAW;
+		// Nobody is looking at it any more, so give the slot back to the server.
+		// DestroyReal is a no-op when no server-side textdraw exists, which the
+		// unguarded TextDrawDestroy here previously was not.
+		GlobalText::DestroyReal(*data);
+		data->visible = false;
 	}
 
 	return 1;
@@ -590,48 +432,29 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawShowForAll(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
-
-	// Sunucuda bir oyuncu yoksa bu fonksiyonu çalýþtýrmayý durdur
 	if (GlobalText::PlayerList.empty()) {
 		return 0;
 	}
 
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	// Aktif gözüken bir kullanýcý yoksa textdrawý yeniden oluþtur
-	if (GlobalText::gTextVisible[textid].empty())
+	if (!GlobalText::Reload(textid, *data))
 	{
-		// TextDraw'ý oluþtur
-		GlobalText::Reload(it);
-
-		// TextDraw oluþturulduysa
-		if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-		{
-			// Tüm oyuncularý gözüküyor olarak ayarla
-			for (std::unordered_set<int>::iterator p = GlobalText::PlayerList.begin(); p != GlobalText::PlayerList.end(); p++)
-			{
-				GlobalText::gTextVisible[textid][*p] = true;
-			}
-
-			// TextDrawý göster
-			TextDrawShowForAll(it->second->real_id);
-		}
-	}
-	else
-	{
-		// Zaten gözüken oyuncu olduðu için gerçek kimlik ile tekrar göster
-		TextDrawShowForAll(it->second->real_id);
+		Plugin_Settings::ILogger(LogType::SHOW_LIMIT_GLOBAL, __func__, INVALID_PLAYER_ID, textid);
+		return 0;
 	}
 
+	std::unordered_set<int>& viewers = GlobalText::gTextVisible[textid];
+	viewers.insert(GlobalText::PlayerList.begin(), GlobalText::PlayerList.end());
+	data->visible = true;
+
+	TextDrawShowForAll(data->real_id);
 	return 1;
 }
 
@@ -642,24 +465,17 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawHideForAll(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
-	
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
-	
-	// Tüm kullanýcýlarý sýfýrla
-	GlobalText::gTextVisible[textid].clear();
 
-	// TextDraw'ý kaldýr
-	TextDrawDestroy(it->second->real_id);
-	it->second->real_id = INVALID_DYNAMIC_PLAYER_TEXTDRAW;
+	GlobalText::gTextVisible[textid].clear();
+	GlobalText::DestroyReal(*data);
+	data->visible = false;
 
 	return 1;
 }
@@ -669,22 +485,19 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawHideForAll(AMX* amx, cell* params)
 //
 cell AMX_NATIVE_CALL Natives::DynamicTextDrawSetString(AMX* amx, cell* params)
 {
-	CHECK_PARAMS(params[0] / sizeof(cell));
+	CHECK_MIN_PARAMS(2);
 
-	int textid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[1]);
 
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->text = service::formattedString(amx, params, 2, 3);
+	data->text = service::formattedString(amx, params, 2, 3);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawSetString(it->second->real_id, it->second->text.c_str());
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawSetString(data->real_id, data->text.c_str());
 	}
 
 	return 1;
@@ -697,25 +510,18 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawSetPreviewModel(AMX* amx, cell* par
 {
 	CHECK_PARAMS(4);
 
-	int
-		textid = static_cast<int>(params[1]),
-		model = static_cast<int>(params[2]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->modelindex = model;
+	data->modelindex = static_cast<int>(params[2]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawSetPreviewModel(it->second->real_id, it->second->modelindex);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawSetPreviewModel(data->real_id, data->modelindex);
 	}
 
 	return 1;
@@ -728,33 +534,21 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawSetPreviewRot(AMX* amx, cell* param
 {
 	CHECK_PARAMS(7);
 
-	int
-		textid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[6], params[7]);
 
-	float
-		rotationX	= amx_ctof(params[2]),
-		rotationY	= amx_ctof(params[3]),
-		rotationZ	= amx_ctof(params[4]),
-		zoom		= amx_ctof(params[5]);
-
-	Plugin_Settings::file = service::getString(amx, params[6]);
-	Plugin_Settings::line = static_cast<int>(params[7]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->fRotX = rotationX;
-	it->second->fRotY = rotationY;
-	it->second->fRotZ = rotationZ;
-	it->second->fZoom = zoom;
+	data->fRotX = amx_ctof(params[2]);
+	data->fRotY = amx_ctof(params[3]);
+	data->fRotZ = amx_ctof(params[4]);
+	data->fZoom = amx_ctof(params[5]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawSetPreviewRot(it->second->real_id, it->second->fRotX, it->second->fRotY, it->second->fRotZ, it->second->fZoom);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawSetPreviewRot(data->real_id, data->fRotX, data->fRotY, data->fRotZ, data->fZoom);
 	}
 
 	return 1;
@@ -767,27 +561,19 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawSetPreviewVehicleColours(AMX* amx, 
 {
 	CHECK_PARAMS(5);
 
-	int
-		textid = static_cast<int>(params[1]),
-		colour1 = static_cast<int>(params[2]),
-		colour2 = static_cast<int>(params[3]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->veh_col1 = colour1;
-	it->second->veh_col2 = colour2;
+	data->veh_col1 = static_cast<int>(params[2]);
+	data->veh_col2 = static_cast<int>(params[3]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		TextDrawSetPreviewVehCol(it->second->real_id, it->second->veh_col1, it->second->veh_col2);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		TextDrawSetPreviewVehCol(data->real_id, data->veh_col1, data->veh_col2);
 	}
 
 	return 1;
@@ -799,8 +585,7 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawSetPreviewVehicleColours(AMX* amx, 
 cell AMX_NATIVE_CALL Natives::IsValidDynamicTextDraw(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(1);
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(static_cast<int>(params[1]));
-	return it != GlobalText::gText->end();
+	return GlobalText::gText.find(static_cast<int>(params[1])) != GlobalText::gText.end();
 }
 
 //
@@ -809,28 +594,21 @@ cell AMX_NATIVE_CALL Natives::IsValidDynamicTextDraw(AMX* amx, cell* params)
 cell AMX_NATIVE_CALL Natives::IsDynamicTextDrawVisibleForPlayer(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
-	
-	int 
-		playerid = static_cast<int>(params[1]), 
-		textid = static_cast<int>(params[2]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	if (GlobalText::Find(textid, __func__) == nullptr) {
 		return 0;
 	}
 
-	std::map<int, bool>::iterator p = GlobalText::gTextVisible[textid].find(playerid);
-	if (p == GlobalText::gTextVisible[textid].end())
-	{
+	auto viewers = GlobalText::gTextVisible.find(textid);
+	if (viewers == GlobalText::gTextVisible.end()) {
 		return 0;
 	}
 
-	return 1;
+	return viewers->second.find(playerid) != viewers->second.end();
 }
 
 //
@@ -840,17 +618,12 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetString(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	service::setString(amx, params[2], params[3], it->second->text.c_str());
-	return 1;
+	return service::setString(amx, params[2], params[3], data->text);
 }
 
 //
@@ -860,36 +633,43 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawSetPos(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(5);
 
-	int
-		textid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	float
-		x = amx_ctof(params[2]),
-		y = amx_ctof(params[3]);
-
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	it->second->create_x = x;
-	it->second->create_y = y;
+	data->create_x = amx_ctof(params[2]);
+	data->create_y = amx_ctof(params[3]);
 
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
+	// Position is fixed at creation time, so an existing textdraw has to be
+	// rebuilt for the move to take effect.
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
 	{
-		TextDrawDestroy(it->second->real_id);
-		it->second->real_id = INVALID_DYNAMIC_PLAYER_TEXTDRAW;
+		const bool wasVisible = data->visible;
 
-		GlobalText::Reload(it);
+		GlobalText::DestroyReal(*data);
 
-		for (std::unordered_set<int>::iterator p = GlobalText::PlayerList.begin(); p != GlobalText::PlayerList.end(); p++)
+		if (!GlobalText::Reload(textid, *data))
 		{
-			TextDrawShowForPlayer(*p, it->second->real_id);
+			Plugin_Settings::ILogger(LogType::SHOW_LIMIT_GLOBAL, __func__, INVALID_PLAYER_ID, textid);
+			return 0;
+		}
+
+		// Re-show only to the players who could already see it. Showing it to
+		// everyone in PlayerList, as this used to, made a move reveal a textdraw
+		// to players it was never shown to.
+		if (wasVisible)
+		{
+			auto viewers = GlobalText::gTextVisible.find(textid);
+			if (viewers != GlobalText::gTextVisible.end())
+			{
+				for (int viewer : viewers->second) {
+					TextDrawShowForPlayer(viewer, data->real_id);
+				}
+			}
 		}
 	}
 
@@ -903,20 +683,15 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetLetterSize(AMX* amx, cell* param
 {
 	CHECK_PARAMS(5);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	service::setFloat(amx, params[2], it->second->lettersize_x);
-	service::setFloat(amx, params[3], it->second->lettersize_y);
+	service::setFloat(amx, params[2], data->lettersize_x);
+	service::setFloat(amx, params[3], data->lettersize_y);
 
 	return 1;
 }
@@ -928,20 +703,15 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetTextSize(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(5);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	service::setFloat(amx, params[2], it->second->textsize_x);
-	service::setFloat(amx, params[3], it->second->textsize_y);
+	service::setFloat(amx, params[2], data->textsize_x);
+	service::setFloat(amx, params[3], data->textsize_y);
 
 	return 1;
 }
@@ -953,20 +723,15 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetPos(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(5);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	service::setFloat(amx, params[2], it->second->create_x);
-	service::setFloat(amx, params[3], it->second->create_y);
+	service::setFloat(amx, params[2], data->create_x);
+	service::setFloat(amx, params[3], data->create_y);
 
 	return 1;
 }
@@ -978,19 +743,10 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetColour(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->color);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->color);
 }
 
 //
@@ -1000,41 +756,23 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetBoxColour(AMX* amx, cell* params
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->boxcolor);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->boxcolor);
 }
 
 //
-// native DynamicTextDrawGetBackgroundCol(Text:textid, const file[], line);
+// native DynamicTextDrawGetBackgroundCo(Text:textid, const file[], line);
 //
 cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetBackgroundColour(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->backgroundcolor);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->backgroundcolor);
 }
 
 //
@@ -1044,19 +782,10 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetShadow(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->shadow);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->shadow);
 }
 
 //
@@ -1066,19 +795,10 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetOutline(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->outline);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->outline);
 }
 
 //
@@ -1088,19 +808,10 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetFont(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->font);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->font);
 }
 
 //
@@ -1110,19 +821,10 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawIsBox(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->usebox);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->usebox);
 }
 
 //
@@ -1132,19 +834,10 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawIsProportional(AMX* amx, cell* para
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->proportional);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->proportional);
 }
 
 //
@@ -1154,19 +847,10 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawIsSelectable(AMX* amx, cell* params
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->selectable);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->selectable);
 }
 
 //
@@ -1176,19 +860,10 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetAlignment(AMX* amx, cell* params
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->alignment);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->alignment);
 }
 
 //
@@ -1198,19 +873,10 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetPreviewModel(AMX* amx, cell* par
 {
 	CHECK_PARAMS(3);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[2], params[3]);
 
-	Plugin_Settings::file = service::getString(amx, params[2]);
-	Plugin_Settings::line = static_cast<int>(params[3]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->modelindex);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->modelindex);
 }
 
 //
@@ -1219,23 +885,18 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetPreviewModel(AMX* amx, cell* par
 cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetPreviewRot(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(7);
-	
-	int textid = static_cast<int>(params[1]);
 
-	Plugin_Settings::file = service::getString(amx, params[6]);
-	Plugin_Settings::line = static_cast<int>(params[7]);
+	Plugin_Settings::SetContext(amx, params[6], params[7]);
 
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	if (data == nullptr) {
 		return 0;
 	}
-	
-	service::setFloat(amx, params[2], it->second->fRotX);
-	service::setFloat(amx, params[3], it->second->fRotY);
-	service::setFloat(amx, params[4], it->second->fRotZ);
-	service::setFloat(amx, params[5], it->second->fZoom);
+
+	service::setFloat(amx, params[2], data->fRotX);
+	service::setFloat(amx, params[3], data->fRotY);
+	service::setFloat(amx, params[4], data->fRotZ);
+	service::setFloat(amx, params[5], data->fZoom);
 
 	return 1;
 }
@@ -1247,20 +908,15 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetPreviewVehicleColours(AMX* amx, 
 {
 	CHECK_PARAMS(5);
 
-	int textid = static_cast<int>(params[1]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	service::setInt(amx, params[2], it->second->veh_col1);
-	service::setInt(amx, params[3], it->second->veh_col2);
+	service::setInt(amx, params[2], data->veh_col1);
+	service::setInt(amx, params[3], data->veh_col2);
 
 	return 1;
 }
@@ -1272,26 +928,25 @@ cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetRealID(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
 
-	int textid = static_cast<int>(params[1]);
-
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
 	service::setInt(amx, params[2], INVALID_DYNAMIC_PLAYER_TEXTDRAW);
 
-	std::unordered_map<int, Text_Data*>::iterator it = GlobalText::gText->find(textid);
-	if (it == GlobalText::gText->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, __func__, INVALID_PLAYER_ID, textid);
+	Text_Data* data = GlobalText::Find(static_cast<int>(params[1]), __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	service::setInt(amx, params[2], it->second->real_id);
+	service::setInt(amx, params[2], data->real_id);
 
 	return 1;
 }
 
+//
+// native DynamicTextDrawGetSize();
+//
 cell AMX_NATIVE_CALL Natives::DynamicTextDrawGetSize(AMX* amx, cell* params)
 {
-	return (GlobalText::gText->empty()) ? (0) : (GlobalText::gText->size());
+	CHECK_PARAMS(0);
+	return static_cast<cell>(GlobalText::gText.size());
 }

--- a/src/natives_player.cpp
+++ b/src/natives_player.cpp
@@ -19,157 +19,76 @@
 #include "slot_manager.hpp"
 #include "textdraw_data.hpp"
 
+//
+// native PlayerText:CreateDynamicPlayerTextDraw(playerid, Float:x, Float:y, const format[], {Float, _}:...);
+//
 cell AMX_NATIVE_CALL Natives::CreateDynamicPlayerTextDraw(AMX* amx, cell* params)
 {
-	// Parametleri kontrol et
-	CHECK_PARAMS(params[0] / sizeof(cell));
+	CHECK_MIN_PARAMS(4);
 
-	// Oyuncu kimligini al
-	int playerid = static_cast<int>(params[1]);
+	const int playerid = static_cast<int>(params[1]);
 
-	if (playerid >= 0 && playerid < MAX_PLAYERS)
-	{
-		// Daha onceden verileri depolamak icin pointer olusturuldu mu kontrol et
-		if (PlayerText::pText[playerid] == nullptr)
-		{
-			// Yeni bir pointer olustur
-			std::unordered_map<int, Text_Data*>* pointer = new std::unordered_map<int, Text_Data*>;
-
-			// Olusturulan pointeri kaydet
-			PlayerText::pText[playerid] = pointer;
-		}
-
-		// Yeni bir kimlik al
-		int auto_increment = slot_manager_player::get_id(playerid);
-
-		// Yeni bir map haritasi olustur (Extra ID) icin
-		std::map<int, int>* map = new std::map<int, int>();
-
-		// Yeni bir vector olustur (Array) verileri icin
-		std::vector<int>* arr = new std::vector<int>();
-
-		// PlayerData verilerini olustur
-		Text_Data* data = new Text_Data();
-		data->real_id = -1;
-		data->create_x = amx_ctof(params[2]);
-		data->create_y = amx_ctof(params[3]);
-		data->text = service::formattedString(amx, params, 4, 5);
-		data->lettersize_x = 0.0;
-		data->lettersize_y = 0.0;
-		data->textsize_x = 0.0;
-		data->textsize_y = 0.0;
-		data->alignment = 1;
-		data->color = -2;
-		data->usebox = 0;
-		data->boxcolor = -2;
-		data->shadow = 2;
-		data->outline = 0;
-		data->backgroundcolor = -2;
-		data->font = 1;
-		data->proportional = 1;
-		data->selectable = 0;
-		data->modelindex = 0;
-		data->fRotX = 0.0;
-		data->fRotY = 0.0;
-		data->fRotZ = 0.0;
-		data->fZoom = 1.0;
-		data->veh_col1 = -2;
-		data->veh_col2 = -2;
-		data->extra_id = map;
-		data->float_data = 0.0;
-		data->array_data = arr;
-
-		// Veriyi pointera aktar
-		PlayerText::pText[playerid]->emplace(auto_increment, data);
-
-		return static_cast<int>(auto_increment);
+	TextMap* pool = PlayerText::Ensure(playerid);
+	if (pool == nullptr) {
+		return INVALID_DYNAMIC_PLAYER_TEXTDRAW;
 	}
 
-	return INVALID_DYNAMIC_PLAYER_TEXTDRAW;
+	const int textid = slot_manager_player::get_id(playerid);
+
+	Text_Data& data = (*pool)[textid];
+	data = Text_Data();
+	data.create_x = amx_ctof(params[2]);
+	data.create_y = amx_ctof(params[3]);
+	data.text = service::formattedString(amx, params, 4, 5);
+
+	return static_cast<cell>(textid);
 }
 
 //
-// DestroyDynamicPlayerTextDraw(playerid, PlayerText:textid, const file[], line);
+// native DestroyDynamicPlayerTextDraw(playerid, PlayerText:textid, const file[], line);
 //
 cell AMX_NATIVE_CALL Natives::DestroyDynamicPlayerTextDraw(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
 
-	int
-		playerid = static_cast<int>(params[1]), 
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)  {
-		PlayerTextDrawDestroy(playerid, it->second->real_id), it->second->real_id = INVALID_DYNAMIC_PLAYER_TEXTDRAW;
-	}
+	PlayerText::DestroyReal(playerid, *data);
 
 	slot_manager_player::remove_id(playerid, textid);
-	delete it->second->extra_id;
-	delete it->second->array_data;
-	delete it->second;
-	PlayerText::pText[playerid]->erase(it);
+	PlayerText::Pool(playerid)->erase(textid);
+
 	return 1;
 }
 
 //
-// DynamicPlayerTextDrawLetterSize(playerid, PlayerText:textid, Float:width, Float:height, const file[], line);
+// native DynamicPlayerTextDrawLetterSize(playerid, PlayerText:textid, Float:width, Float:height, const file[], line);
 //
 cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawLetterSize(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(6);
-	
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
-	
-	float
-		width = amx_ctof(params[3]), 
-		height = amx_ctof(params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[5]);
-	Plugin_Settings::line = static_cast<int>(params[6]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[5], params[6]);
 
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->lettersize_x = amx_ctof(params[3]);
+	data->lettersize_y = amx_ctof(params[4]);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->lettersize_x = width;
-	it->second->lettersize_y = height;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)  {
-		PlayerTextDrawLetterSize(playerid, it->second->real_id, it->second->lettersize_x, it->second->lettersize_y);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawLetterSize(playerid, data->real_id, data->lettersize_x, data->lettersize_y);
 	}
 
 	return 1;
@@ -182,38 +101,20 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawTextSize(AMX* amx, cell* para
 {
 	CHECK_PARAMS(6);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[5], params[6]);
 
-	float
-		width = amx_ctof(params[3]),
-		height = amx_ctof(params[4]);
-
-	Plugin_Settings::file = service::getString(amx, params[5]);
-	Plugin_Settings::line = static_cast<int>(params[6]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->textsize_x = amx_ctof(params[3]);
+	data->textsize_y = amx_ctof(params[4]);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->textsize_x = width;
-	it->second->textsize_y = height;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawTextSize(playerid, it->second->real_id, it->second->textsize_x, it->second->textsize_y);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawTextSize(playerid, data->real_id, data->textsize_x, data->textsize_y);
 	}
 
 	return 1;
@@ -226,34 +127,19 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawAlignment(AMX* amx, cell* par
 {
 	CHECK_PARAMS(5);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]),
-		alignment = static_cast<int>(params[3]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->alignment = static_cast<int>(params[3]);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->alignment = alignment;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawAlignment(playerid, it->second->real_id, it->second->alignment);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawAlignment(playerid, data->real_id, data->alignment);
 	}
 
 	return 1;
@@ -266,34 +152,19 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawColour(AMX* amx, cell* params
 {
 	CHECK_PARAMS(5);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]),
-		textColour = static_cast<int>(params[3]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->color = static_cast<int>(params[3]);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->color = textColour;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawColor(playerid, it->second->real_id, it->second->color);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawColor(playerid, data->real_id, data->color);
 	}
 
 	return 1;
@@ -306,34 +177,19 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawUseBox(AMX* amx, cell* params
 {
 	CHECK_PARAMS(5);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]),
-		enableBox = static_cast<int>(params[3]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->usebox = static_cast<int>(params[3]);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->usebox = enableBox;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawUseBox(playerid, it->second->real_id, it->second->usebox);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawUseBox(playerid, data->real_id, data->usebox);
 	}
 
 	return 1;
@@ -346,34 +202,19 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawBoxColor(AMX* amx, cell* para
 {
 	CHECK_PARAMS(5);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]),
-		boxColour = static_cast<int>(params[3]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->boxcolor = static_cast<int>(params[3]);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->boxcolor = boxColour;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawBoxColor(playerid, it->second->real_id, it->second->boxcolor);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawBoxColor(playerid, data->real_id, data->boxcolor);
 	}
 
 	return 1;
@@ -386,34 +227,19 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawSetShadow(AMX* amx, cell* par
 {
 	CHECK_PARAMS(5);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]),
-		shadowSize = static_cast<int>(params[3]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->shadow = static_cast<int>(params[3]);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->shadow = shadowSize;
-	
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawSetShadow(playerid, it->second->real_id, it->second->shadow);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawSetShadow(playerid, data->real_id, data->shadow);
 	}
 
 	return 1;
@@ -426,36 +252,21 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawSetOutline(AMX* amx, cell* pa
 {
 	CHECK_PARAMS(5);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]),
-		outlineSize = static_cast<int>(params[3]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
+	data->outline = static_cast<int>(params[3]);
+
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawSetOutline(playerid, data->real_id, data->outline);
 	}
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->outline = outlineSize;
-	
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawSetOutline(playerid, it->second->real_id, it->second->outline);
-	}
-	
 	return 1;
 }
 
@@ -466,34 +277,19 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawBackgroundColour(AMX* amx, ce
 {
 	CHECK_PARAMS(5);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]),
-		backgroundColour = static_cast<int>(params[3]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->backgroundcolor = static_cast<int>(params[3]);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->backgroundcolor = backgroundColour;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawBackgroundColor(playerid, it->second->real_id, it->second->backgroundcolor);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawBackgroundColor(playerid, data->real_id, data->backgroundcolor);
 	}
 
 	return 1;
@@ -506,34 +302,19 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawFont(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(5);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]),
-		font = static_cast<int>(params[3]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->font = static_cast<int>(params[3]);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->font = font;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawFont(playerid, it->second->real_id, it->second->font);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawFont(playerid, data->real_id, data->font);
 	}
 
 	return 1;
@@ -546,34 +327,19 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawSetProportional(AMX* amx, cel
 {
 	CHECK_PARAMS(5);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]),
-		proportional = static_cast<int>(params[3]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->proportional = static_cast<int>(params[3]);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->proportional = proportional;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawSetProportional(playerid, it->second->real_id, it->second->proportional);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawSetProportional(playerid, data->real_id, data->proportional);
 	}
 
 	return 1;
@@ -586,34 +352,19 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawSetSelectable(AMX* amx, cell*
 {
 	CHECK_PARAMS(5);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]),
-		selectable = static_cast<int>(params[3]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->selectable = static_cast<int>(params[3]);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->selectable = selectable;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawSetSelectable(playerid, it->second->real_id, it->second->selectable);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawSetSelectable(playerid, data->real_id, data->selectable);
 	}
 
 	return 1;
@@ -626,110 +377,25 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawShow(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
+	// Reload creates and configures the textdraw, and is a no-op when one already
+	// exists. This used to be ~70 lines duplicated from PlayerText::Reload.
+	if (!PlayerText::Reload(playerid, *data))
 	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
+		Plugin_Settings::ILogger(LogType::SHOW_LIMIT_PLAYER, __func__, playerid, textid);
 		return 0;
 	}
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	if (it->second->real_id == INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		int text_id = CreatePlayerTextDraw(playerid, it->second->create_x, it->second->create_y, it->second->text.c_str());
-		if (text_id == INVALID_TEXT_DRAW)
-		{
-			Plugin_Settings::ILogger(LogType::SHOW_LIMIT_PLAYER, __func__, playerid, textid);
-			return 0;
-		}
-		else
-		{
-			if (it->second->lettersize_x != PlayerText::Default.lettersize_x || it->second->lettersize_y != PlayerText::Default.lettersize_y) {
-				PlayerTextDrawLetterSize(playerid, text_id, it->second->lettersize_x, it->second->lettersize_y);
-			}
-
-			if (it->second->textsize_x != PlayerText::Default.textsize_x || it->second->textsize_y != PlayerText::Default.textsize_y) {
-				PlayerTextDrawTextSize(playerid, text_id, it->second->textsize_x, it->second->textsize_y);
-			}
-
-			if (it->second->alignment != PlayerText::Default.alignment) {
-				PlayerTextDrawAlignment(playerid, text_id, it->second->alignment);
-			}
-
-			if (it->second->color != PlayerText::Default.color) {
-				PlayerTextDrawColor(playerid, text_id, it->second->color);
-			}
-
-			if (it->second->usebox != PlayerText::Default.usebox) {
-				PlayerTextDrawUseBox(playerid, text_id, it->second->usebox);
-			}
-
-			if (it->second->boxcolor != PlayerText::Default.boxcolor) {
-				PlayerTextDrawBoxColor(playerid, text_id, it->second->boxcolor);
-			}
-
-			if (it->second->shadow != PlayerText::Default.shadow) {
-				PlayerTextDrawSetShadow(playerid, text_id, it->second->shadow);
-			}
-
-			if (it->second->outline != PlayerText::Default.outline) {
-				PlayerTextDrawSetOutline(playerid, text_id, it->second->outline);
-			}
-
-			if (it->second->backgroundcolor != PlayerText::Default.backgroundcolor) {
-				PlayerTextDrawBackgroundColor(playerid, text_id, it->second->backgroundcolor);
-			}
-
-			if (it->second->font != PlayerText::Default.font) {
-				PlayerTextDrawFont(playerid, text_id, it->second->font);
-			}
-
-			if (it->second->proportional != PlayerText::Default.proportional) {
-				PlayerTextDrawSetProportional(playerid, text_id, it->second->proportional);
-			}
-
-			if (it->second->selectable != PlayerText::Default.selectable) {
-				PlayerTextDrawSetSelectable(playerid, text_id, it->second->selectable);
-			}
-
-			if (it->second->font == TEXT_DRAW_FONT_MODEL_PREVIEW)
-			{
-				if (it->second->modelindex != PlayerText::Default.modelindex) {
-					PlayerTextDrawSetPreviewModel(playerid, text_id, it->second->modelindex);
-				}
-
-				if (it->second->fRotX != PlayerText::Default.fRotX || it->second->fRotY != PlayerText::Default.fRotY || it->second->fRotZ != PlayerText::Default.fRotZ || it->second->fZoom != PlayerText::Default.fZoom) {
-					PlayerTextDrawSetPreviewRot(playerid, text_id, it->second->fRotX, it->second->fRotY, it->second->fRotZ, it->second->fZoom);
-				}
-
-				if (it->second->veh_col1 != PlayerText::Default.veh_col1 || it->second->veh_col2 != PlayerText::Default.veh_col2) {
-					PlayerTextDrawSetPreviewVehCol(playerid, text_id, it->second->veh_col1, it->second->veh_col2);
-				}
-			}
-
-			it->second->real_id = text_id;
-			PlayerTextDrawShow(playerid, it->second->real_id);
-		}
-	}
-	else
-	{
-		PlayerTextDrawShow(playerid, it->second->real_id);
-	}
+	data->visible = true;
+	PlayerTextDrawShow(playerid, data->real_id);
 
 	return 1;
 }
@@ -741,32 +407,19 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawHide(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawDestroy(playerid, it->second->real_id), it->second->real_id = INVALID_DYNAMIC_PLAYER_TEXTDRAW;
-	}
+	// Destroying rather than hiding is what frees the player's slot, which is the
+	// point of the streamer.
+	PlayerText::DestroyReal(playerid, *data);
+	data->visible = false;
 
 	return 1;
 }
@@ -776,32 +429,20 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawHide(AMX* amx, cell* params)
 //
 cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawSetString(AMX* amx, cell* params)
 {
-	CHECK_PARAMS(params[0] / sizeof(cell));
+	CHECK_MIN_PARAMS(3);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
 
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->text = service::formattedString(amx, params, 3, 4);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->text = service::formattedString(amx, params, 3, 4);
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawSetString(playerid, it->second->real_id, it->second->text.c_str());
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawSetString(playerid, data->real_id, data->text.c_str());
 	}
 
 	return 1;
@@ -814,34 +455,19 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawSetPreviewModel(AMX* amx, cel
 {
 	CHECK_PARAMS(5);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]),
-		model = static_cast<int>(params[3]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->modelindex = static_cast<int>(params[3]);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->modelindex = model;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawSetPreviewModel(playerid, it->second->real_id, it->second->modelindex);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawSetPreviewModel(playerid, data->real_id, data->modelindex);
 	}
 
 	return 1;
@@ -854,44 +480,24 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawSetPreviewRot(AMX* amx, cell*
 {
 	CHECK_PARAMS(8);
 
-	int
-		playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[7], params[8]);
 
-	float
-		rotationX = amx_ctof(params[3]),
-		rotationY = amx_ctof(params[4]),
-		rotationZ = amx_ctof(params[5]),
-		zoom = amx_ctof(params[6]);
-
-	Plugin_Settings::file = service::getString(amx, params[7]);
-	Plugin_Settings::line = static_cast<int>(params[8]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
+	data->fRotX = amx_ctof(params[3]);
+	data->fRotY = amx_ctof(params[4]);
+	data->fRotZ = amx_ctof(params[5]);
+	data->fZoom = amx_ctof(params[6]);
+
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawSetPreviewRot(playerid, data->real_id, data->fRotX, data->fRotY, data->fRotZ, data->fZoom);
 	}
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->fRotX = rotationX;
-	it->second->fRotY = rotationY;
-	it->second->fRotZ = rotationZ;
-	it->second->fZoom = zoom;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawSetPreviewRot(playerid, it->second->real_id, it->second->fRotX, it->second->fRotY, it->second->fRotZ, it->second->fZoom);
-	}
 	return 1;
 }
 
@@ -902,37 +508,20 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawSetPreviewVehicleColours(AMX*
 {
 	CHECK_PARAMS(6);
 
-	int
-		playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]),
-		colour1 = static_cast<int>(params[3]),
-		colour2 = static_cast<int>(params[4]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[5], params[6]);
 
-	Plugin_Settings::file = service::getString(amx, params[5]);
-	Plugin_Settings::line = static_cast<int>(params[6]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
+	data->veh_col1 = static_cast<int>(params[3]);
+	data->veh_col2 = static_cast<int>(params[4]);
 
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->veh_col1 = colour1;
-	it->second->veh_col2 = colour2;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawSetPreviewVehCol(playerid, it->second->real_id, it->second->veh_col1, it->second->veh_col2);
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		PlayerTextDrawSetPreviewVehCol(playerid, data->real_id, data->veh_col1, data->veh_col2);
 	}
 
 	return 1;
@@ -945,23 +534,19 @@ cell AMX_NATIVE_CALL Natives::IsValidDynamicPlayerTextDraw(AMX* amx, cell* param
 {
 	CHECK_PARAMS(2);
 
-	int
-		playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
 
 	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr) {
+	TextMap* pool = PlayerText::Pool(playerid);
+	if (pool == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid]->find(textid) == PlayerText::pText[playerid]->end()) {
-		return 0;
-	}
-
-	return 1;
+	return pool->find(textid) != pool->end();
 }
 
 //
@@ -971,31 +556,16 @@ cell AMX_NATIVE_CALL Natives::IsDynamicPlayerTextDrawVisible(AMX* amx, cell* par
 {
 	CHECK_PARAMS(4);
 
-	int
-		playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	return it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW;
+	return data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW;
 }
 
 //
@@ -1005,30 +575,15 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetString(AMX* amx, cell* par
 {
 	CHECK_PARAMS(4);
 
-	int
-		playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
 
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	service::setString(amx, params[3], params[4], it->second->text.c_str());
-
-	return 1;
+	return service::setString(amx, params[3], params[4], data->text);
 }
 
 //
@@ -1038,41 +593,38 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawSetPos(AMX* amx, cell* params
 {
 	CHECK_PARAMS(6);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[5], params[6]);
 
-	float
-		x = amx_ctof(params[3]),
-		y = amx_ctof(params[4]);
-
-	Plugin_Settings::file = service::getString(amx, params[5]);
-	Plugin_Settings::line = static_cast<int>(params[6]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
+	data->create_x = amx_ctof(params[3]);
+	data->create_y = amx_ctof(params[4]);
+
+	// Position is fixed at creation time, so an existing textdraw has to be
+	// rebuilt for the move to take effect.
+	if (data->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW)
 	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
+		const bool wasVisible = data->visible;
+
+		PlayerText::DestroyReal(playerid, *data);
+
+		if (!PlayerText::Reload(playerid, *data))
+		{
+			Plugin_Settings::ILogger(LogType::SHOW_LIMIT_PLAYER, __func__, playerid, textid);
+			return 0;
+		}
+
+		// Only put it back on screen if it was on screen to begin with; this used
+		// to show a hidden textdraw as a side effect of moving it.
+		if (wasVisible) {
+			PlayerTextDrawShow(playerid, data->real_id);
+		}
 	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	it->second->create_x = x;
-	it->second->create_y = y;
-
-	if (it->second->real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
-		PlayerTextDrawDestroy(playerid, it->second->real_id), it->second->real_id = INVALID_DYNAMIC_PLAYER_TEXTDRAW;
-	}
-
-	PlayerText::Reload(playerid, it);
 
 	return 1;
 }
@@ -1084,31 +636,17 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetLetterSize(AMX* amx, cell*
 {
 	CHECK_PARAMS(6);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[5], params[6]);
 
-	Plugin_Settings::file = service::getString(amx, params[5]);
-	Plugin_Settings::line = static_cast<int>(params[6]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	service::setFloat(amx, params[3], it->second->lettersize_x);
-	service::setFloat(amx, params[4], it->second->lettersize_y);
+	service::setFloat(amx, params[3], data->lettersize_x);
+	service::setFloat(amx, params[4], data->lettersize_y);
 
 	return 1;
 }
@@ -1120,31 +658,17 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetTextSize(AMX* amx, cell* p
 {
 	CHECK_PARAMS(6);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[5], params[6]);
 
-	Plugin_Settings::file = service::getString(amx, params[5]);
-	Plugin_Settings::line = static_cast<int>(params[6]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	service::setFloat(amx, params[3], it->second->textsize_x);
-	service::setFloat(amx, params[4], it->second->textsize_x);
+	service::setFloat(amx, params[3], data->textsize_x);
+	service::setFloat(amx, params[4], data->textsize_y);
 
 	return 1;
 }
@@ -1156,31 +680,17 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetPos(AMX* amx, cell* params
 {
 	CHECK_PARAMS(6);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[5], params[6]);
 
-	Plugin_Settings::file = service::getString(amx, params[5]);
-	Plugin_Settings::line = static_cast<int>(params[6]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	service::setFloat(amx, params[3], it->second->create_x);
-	service::setFloat(amx, params[4], it->second->create_y);
+	service::setFloat(amx, params[3], data->create_x);
+	service::setFloat(amx, params[4], data->create_y);
 
 	return 1;
 }
@@ -1192,30 +702,10 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetColour(AMX* amx, cell* par
 {
 	CHECK_PARAMS(4);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
-		return 0;
-	}
-
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->color);
+	Text_Data* data = PlayerText::Find(static_cast<int>(params[1]), static_cast<int>(params[2]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->color);
 }
 
 //
@@ -1225,30 +715,10 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetBoxColour(AMX* amx, cell* 
 {
 	CHECK_PARAMS(4);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
-		return 0;
-	}
-
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->boxcolor);
+	Text_Data* data = PlayerText::Find(static_cast<int>(params[1]), static_cast<int>(params[2]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->boxcolor);
 }
 
 //
@@ -1258,30 +728,10 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetBackgroundColour(AMX* amx,
 {
 	CHECK_PARAMS(4);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
-		return 0;
-	}
-
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->backgroundcolor);
+	Text_Data* data = PlayerText::Find(static_cast<int>(params[1]), static_cast<int>(params[2]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->backgroundcolor);
 }
 
 //
@@ -1291,30 +741,10 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetShadow(AMX* amx, cell* par
 {
 	CHECK_PARAMS(4);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
-		return 0;
-	}
-
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->shadow);
+	Text_Data* data = PlayerText::Find(static_cast<int>(params[1]), static_cast<int>(params[2]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->shadow);
 }
 
 //
@@ -1324,30 +754,10 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetOutline(AMX* amx, cell* pa
 {
 	CHECK_PARAMS(4);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
-		return 0;
-	}
-
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->outline);
+	Text_Data* data = PlayerText::Find(static_cast<int>(params[1]), static_cast<int>(params[2]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->outline);
 }
 
 //
@@ -1357,30 +767,10 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetFont(AMX* amx, cell* param
 {
 	CHECK_PARAMS(4);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
-		return 0;
-	}
-
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->font);
+	Text_Data* data = PlayerText::Find(static_cast<int>(params[1]), static_cast<int>(params[2]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->font);
 }
 
 //
@@ -1390,30 +780,10 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawIsBox(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(4);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
-		return 0;
-	}
-
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->usebox);
+	Text_Data* data = PlayerText::Find(static_cast<int>(params[1]), static_cast<int>(params[2]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->usebox);
 }
 
 //
@@ -1423,30 +793,10 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawIsProportional(AMX* amx, cell
 {
 	CHECK_PARAMS(4);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
-		return 0;
-	}
-
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->proportional);
+	Text_Data* data = PlayerText::Find(static_cast<int>(params[1]), static_cast<int>(params[2]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->proportional);
 }
 
 //
@@ -1456,30 +806,10 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawIsSelectable(AMX* amx, cell* 
 {
 	CHECK_PARAMS(4);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
-		return 0;
-	}
-
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->selectable);
+	Text_Data* data = PlayerText::Find(static_cast<int>(params[1]), static_cast<int>(params[2]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->selectable);
 }
 
 //
@@ -1489,30 +819,10 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetAlignment(AMX* amx, cell* 
 {
 	CHECK_PARAMS(4);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
-		return 0;
-	}
-
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->alignment);
+	Text_Data* data = PlayerText::Find(static_cast<int>(params[1]), static_cast<int>(params[2]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->alignment);
 }
 
 //
@@ -1522,30 +832,10 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetPreviewModel(AMX* amx, cel
 {
 	CHECK_PARAMS(4);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[3], params[4]);
 
-	Plugin_Settings::file = service::getString(amx, params[3]);
-	Plugin_Settings::line = static_cast<int>(params[4]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
-		return 0;
-	}
-
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	return static_cast<int>(it->second->modelindex);
+	Text_Data* data = PlayerText::Find(static_cast<int>(params[1]), static_cast<int>(params[2]), __func__);
+	return (data == nullptr) ? 0 : static_cast<cell>(data->modelindex);
 }
 
 //
@@ -1555,33 +845,19 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetPreviewRot(AMX* amx, cell*
 {
 	CHECK_PARAMS(8);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[7], params[8]);
 
-	Plugin_Settings::file = service::getString(amx, params[7]);
-	Plugin_Settings::line = static_cast<int>(params[8]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	service::setFloat(amx, params[3], it->second->fRotX);
-	service::setFloat(amx, params[4], it->second->fRotY);
-	service::setFloat(amx, params[5], it->second->fRotZ);
-	service::setFloat(amx, params[6], it->second->fZoom);
+	service::setFloat(amx, params[3], data->fRotX);
+	service::setFloat(amx, params[4], data->fRotY);
+	service::setFloat(amx, params[5], data->fRotZ);
+	service::setFloat(amx, params[6], data->fZoom);
 
 	return 1;
 }
@@ -1593,31 +869,17 @@ cell AMX_NATIVE_CALL Natives::DynamicPlayerTextDrawGetPreviewVehicleColours(AMX*
 {
 	CHECK_PARAMS(6);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[5], params[6]);
 
-	Plugin_Settings::file = service::getString(amx, params[5]);
-	Plugin_Settings::line = static_cast<int>(params[6]);
-
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	service::setInt(amx, params[3], it->second->veh_col1);
-	service::setInt(amx, params[4], it->second->veh_col2);
+	service::setInt(amx, params[3], data->veh_col1);
+	service::setInt(amx, params[4], data->veh_col2);
 
 	return 1;
 }
@@ -1629,51 +891,41 @@ cell AMX_NATIVE_CALL Natives::PlayerTextDrawGetRealID(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(5);
 
-	int playerid = static_cast<int>(params[1]),
-		textid = static_cast<int>(params[2]);
-
-	Plugin_Settings::file = service::getString(amx, params[4]);
-	Plugin_Settings::line = static_cast<int>(params[5]);
+	const int playerid = static_cast<int>(params[1]);
+	const int textid = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[4], params[5]);
 
 	service::setInt(amx, params[3], INVALID_DYNAMIC_PLAYER_TEXTDRAW);
 
-	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+	Text_Data* data = PlayerText::Find(playerid, textid, __func__);
+	if (data == nullptr) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
-	{
-		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, textid);
-		return 0;
-	}
-
-	auto it = PlayerText::pText[playerid]->find(textid);
-	if (it == PlayerText::pText[playerid]->end())
-	{
-		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, __func__, playerid, textid);
-		return 0;
-	}
-
-	service::setInt(amx, params[3], it->second->real_id);
+	service::setInt(amx, params[3], data->real_id);
 
 	return 1;
 }
 
+//
+// native PlayerTextDrawGetSize(playerid);
+//
 cell AMX_NATIVE_CALL Natives::PlayerTextDrawGetSize(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(1);
 
-	int playerid = static_cast<int>(params[1]);
+	const int playerid = static_cast<int>(params[1]);
 
 	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
 		return 0;
 	}
 
-	if (PlayerText::pText[playerid] == nullptr)
+	TextMap* pool = PlayerText::Pool(playerid);
+	if (pool == nullptr)
 	{
 		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, __func__, playerid, 0);
 		return 0;
 	}
 
-	return (PlayerText::pText[playerid]->empty()) ? (0) : (PlayerText::pText[playerid]->size());
+	return static_cast<cell>(pool->size());
 }

--- a/src/natives_plugin.cpp
+++ b/src/natives_plugin.cpp
@@ -19,73 +19,70 @@
 #include "service.hpp"
 
 bool Plugin_Settings::logMode = true;
-std::string Plugin_Settings::file = "unknown";
-int Plugin_Settings::line;
+AMX* Plugin_Settings::amx = nullptr;
+cell Plugin_Settings::fileParam = 0;
+int Plugin_Settings::line = 0;
 
 cell AMX_NATIVE_CALL Natives::TDLogger(AMX* amx, cell* params)
 {
 	CHECK_PARAMS(2);
-	Plugin_Settings::file = service::getString(amx, params[1]);
-	Plugin_Settings::line = static_cast<int>(params[2]);
+	Plugin_Settings::SetContext(amx, params[1], params[2]);
 	return 1;
 }
 
-void Plugin_Settings::ILogger(LogType type, std::string funcs, int playerid, int textid)
+namespace
 {
-	if (Plugin_Settings::logMode == true)
+	// Resolved only when a message is actually emitted, so the common path costs
+	// three stores instead of an AMX string read and a heap allocation.
+	std::string currentFile()
 	{
-		if (type == LogType::CREATE_PLAYER_TEXTDRAW)
-		{
-			sampgdk::logprintf("[textdraw.streamer] %s: First use the CreatePlayerTextDraw function. (playerid: %d, textId: %d) (%s:%d)"
-			,
-				funcs.c_str(),
-				playerid,
-				textid,
-				Plugin_Settings::file.c_str(),
-				Plugin_Settings::line
-			);
+		if (Plugin_Settings::amx == nullptr) {
+			return std::string("unknown");
 		}
-		else if (type == LogType::FIND_PLAYER_TEXT)
-		{
-			sampgdk::logprintf("[textdraw.streamer] %s: No such id was found. (playerid: %d, textId: %d) (%s:%d)"
-			,
-				funcs.c_str(),
-				playerid,
-				textid,
-				Plugin_Settings::file.c_str(),
-				Plugin_Settings::line
-			);
-		}
-		else if (type == LogType::SHOW_LIMIT_PLAYER)
-		{
-			sampgdk::logprintf("[textdraw.streamer] %s: A maximum of %d textdraws can be displayed on a player. (playerid: %d, textId: %d) (%s:%d)"
-			,
-				funcs.c_str(),
-				MAX_PLAYER_TEXT_DRAWS,
-				playerid,
-				textid,
-				Plugin_Settings::file.c_str(),
-				Plugin_Settings::line
-			);
-		}
-		else if (type == LogType::FIND_GLOBAL_TEXT)
-		{
-			sampgdk::logprintf("[textdraw.streamer] %s: No such id was found. (textId: %d) (%s:%d)"
-			,
-				funcs.c_str(),
-				textid,
-				Plugin_Settings::file.c_str(),
-				Plugin_Settings::line
-			);
-		}
-		else if (type == LogType::INVALID_TYPE)
-		{
-			sampgdk::logprintf("[textdraw.streamer] %s: Type format is invalid. (%s:%d)"
-			,
-				funcs.c_str(),
-				Plugin_Settings::file.c_str(),
-				Plugin_Settings::line
-			);
-		}
+
+		std::string file = service::getString(Plugin_Settings::amx, Plugin_Settings::fileParam);
+		return file.empty() ? std::string("unknown") : file;
+	}
+}
+
+void Plugin_Settings::ILogger(LogType type, const char* funcs, int playerid, int textid)
+{
+	if (!Plugin_Settings::logMode) {
+		return;
+	}
+
+	const std::string file = currentFile();
+
+	switch (type)
+	{
+		case LogType::CREATE_PLAYER_TEXTDRAW:
+			sampgdk::logprintf("[textdraw.streamer] %s: First use the CreatePlayerTextDraw function. (playerid: %d, textId: %d) (%s:%d)",
+				funcs, playerid, textid, file.c_str(), Plugin_Settings::line);
+			break;
+
+		case LogType::FIND_PLAYER_TEXT:
+			sampgdk::logprintf("[textdraw.streamer] %s: No such id was found. (playerid: %d, textId: %d) (%s:%d)",
+				funcs, playerid, textid, file.c_str(), Plugin_Settings::line);
+			break;
+
+		case LogType::SHOW_LIMIT_PLAYER:
+			sampgdk::logprintf("[textdraw.streamer] %s: A maximum of %d textdraws can be displayed on a player. (playerid: %d, textId: %d) (%s:%d)",
+				funcs, MAX_PLAYER_TEXT_DRAWS, playerid, textid, file.c_str(), Plugin_Settings::line);
+			break;
+
+		case LogType::FIND_GLOBAL_TEXT:
+			sampgdk::logprintf("[textdraw.streamer] %s: No such id was found. (textId: %d) (%s:%d)",
+				funcs, textid, file.c_str(), Plugin_Settings::line);
+			break;
+
+		case LogType::SHOW_LIMIT_GLOBAL:
+			sampgdk::logprintf("[textdraw.streamer] %s: A maximum of %d global textdraws can be created. (textId: %d) (%s:%d)",
+				funcs, MAX_TEXT_DRAWS, textid, file.c_str(), Plugin_Settings::line);
+			break;
+
+		case LogType::INVALID_TYPE:
+			sampgdk::logprintf("[textdraw.streamer] %s: Type format is invalid. (%s:%d)",
+				funcs, file.c_str(), Plugin_Settings::line);
+			break;
 	}
 }

--- a/src/plugin_version.hpp
+++ b/src/plugin_version.hpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
-#define		MINOR		(2)
-#define		MAJOR		(0)
-#define		PATCH		(3)
+// The original header mislabeled these: MINOR held the major version (2) and
+// MAJOR held the minor (0), which printed correctly by luck.
+#define		VERSION_MAJOR	(2)
+#define		VERSION_MINOR	(0)
+#define		VERSION_PATCH	(3)

--- a/src/plugin_version.hpp
+++ b/src/plugin_version.hpp
@@ -18,4 +18,4 @@
 // MAJOR held the minor (0), which printed correctly by luck.
 #define		VERSION_MAJOR	(2)
 #define		VERSION_MINOR	(0)
-#define		VERSION_PATCH	(3)
+#define		VERSION_PATCH	(5)

--- a/src/service.cpp
+++ b/src/service.cpp
@@ -17,248 +17,369 @@
 #include "service.hpp"
 #include "fmt/printf.h"
 
-void service::setInt(AMX* amx, cell output, int value)
+#include <climits>
+#include <vector>
+
+bool service::setInt(AMX* amx, cell output, int value)
 {
-	cell* address;
-	amx_GetAddr(amx, output, &address);
-	*address = value;
+	cell* address = nullptr;
+	if (amx_GetAddr(amx, output, &address) != AMX_ERR_NONE || address == nullptr) {
+		return false;
+	}
+
+	*address = static_cast<cell>(value);
+	return true;
 }
 
-void service::setFloat(AMX* amx, cell output, float value)
+bool service::setFloat(AMX* amx, cell output, float value)
 {
-	cell* address;
-	amx_GetAddr(amx, output, &address);
+	cell* address = nullptr;
+	if (amx_GetAddr(amx, output, &address) != AMX_ERR_NONE || address == nullptr) {
+		return false;
+	}
+
 	*address = amx_ftoc(value);
+	return true;
 }
 
-void service::setString(AMX* amx, cell output, cell size, std::string string)
+bool service::setString(AMX* amx, cell output, cell size, const std::string& string)
 {
-	cell* address = NULL;
-	amx_GetAddr(amx, output, &address);
+	if (size <= 0) {
+		return false;
+	}
+
+	cell* address = nullptr;
+	if (amx_GetAddr(amx, output, &address) != AMX_ERR_NONE || address == nullptr) {
+		return false;
+	}
+
 	amx_SetString(address, string.c_str(), 0, 0, static_cast<size_t>(size));
+	return true;
 }
 
 std::string service::getString(AMX* amx, cell param)
 {
 	cell* addr = nullptr;
-	amx_GetAddr(amx, param, &addr);
+	if (amx_GetAddr(amx, param, &addr) != AMX_ERR_NONE || addr == nullptr) {
+		return std::string();
+	}
 
 	int len = 0;
-	amx_StrLen(addr, &len);
+	if (amx_StrLen(addr, &len) != AMX_ERR_NONE || len <= 0) {
+		return std::string();
+	}
 
-	std::string string(len, ' ');
-	amx_GetString(&string[0], addr, 0, len + 1);
-	return string;
+	// A separate buffer of len + 1: amx_GetString writes a terminator past the
+	// last character, which must not land on a std::string's internal one.
+	std::vector<char> buffer(static_cast<size_t>(len) + 1, '\0');
+	if (amx_GetString(buffer.data(), addr, 0, buffer.size()) != AMX_ERR_NONE) {
+		return std::string();
+	}
+
+	return std::string(buffer.data(), static_cast<size_t>(len));
 }
 
-std::string service::formattedString(AMX* amx, cell* params, cell text_index, int32_t args_offset)
+namespace
 {
-	// Argüman sayýsýný al
-	int max_args = params[0] / sizeof(cell);
+	// Upper bound on a single conversion's padded output. Without this a script
+	// could write "%999999999d" and force a gigabyte-sized allocation inside fmt.
+	const int kMaxFieldWidth = 8192;
 
-	// Formatlanacak metini al
-	std::string metin = getString(amx, params[text_index]);
-
-	// Argüman sayýsý offset sayýsýna ulaþýyor ve geçiyorsa formatlama aþamasýna geç
-	if (max_args >= args_offset)
+	// The character classification functions are UB on negative values, and this
+	// plugin is routinely handed non-ASCII text.
+	inline bool isDigitChar(char c)
 	{
-		// Metini tarayacak index deðerimiz
-		size_t index = 0;
+		return c >= '0' && c <= '9';
+	}
 
-		// Argümanýn baþlangýç offsetini ayarla
-		int args_count = args_offset;
+	inline bool isFlagChar(char c)
+	{
+		return c == '-' || c == '+' || c == ' ' || c == '#' || c == '0';
+	}
 
-		// Döngü ile metinleri tara
-		while (index < metin.length())
+	// Accepted so that "%ld" is not treated as malformed, then dropped: every
+	// value substituted below is already an int, a double or a string.
+	inline bool isLengthChar(char c)
+	{
+		return c == 'h' || c == 'l' || c == 'L' || c == 'z' || c == 'j' || c == 't';
+	}
+
+	inline bool isIntConv(char c)
+	{
+		return c == 'd' || c == 'i' || c == 'o' || c == 'x' || c == 'X' || c == 'u';
+	}
+
+	inline bool isFloatConv(char c)
+	{
+		return c == 'f' || c == 'F' || c == 'e' || c == 'E'
+			|| c == 'g' || c == 'G' || c == 'a' || c == 'A';
+	}
+
+	// Resolves params[index], which in a Pawn variadic native is a reference.
+	bool argAddress(AMX* amx, const cell* params, int index, cell** out)
+	{
+		if (amx_GetAddr(amx, params[index], out) != AMX_ERR_NONE || *out == nullptr) {
+			return false;
+		}
+		return true;
+	}
+
+	struct Spec
+	{
+		std::string	flags;
+		std::string	width;
+		std::string	precision;
+		bool		has_precision	= false;
+		bool		star_width		= false;
+		bool		star_precision	= false;
+		char		conv			= '\0';
+		size_t		end				= 0;	// index just past the conversion character
+		bool		valid			= false;
+	};
+
+	// Parses "% [flags] [width|*] [. [precision|*]] [length] conversion" starting
+	// at the '%' in format[start]. Never reads past format.size().
+	Spec parseSpec(const std::string& format, size_t start)
+	{
+		Spec spec;
+		const size_t n = format.size();
+		size_t i = start + 1;
+
+		while (i < n && isFlagChar(format[i])) {
+			spec.flags.push_back(format[i++]);
+		}
+
+		if (i < n && format[i] == '*') {
+			spec.star_width = true;
+			++i;
+		}
+		else {
+			while (i < n && isDigitChar(format[i])) {
+				spec.width.push_back(format[i++]);
+			}
+		}
+
+		if (i < n && format[i] == '.') {
+			spec.has_precision = true;
+			++i;
+
+			if (i < n && format[i] == '*') {
+				spec.star_precision = true;
+				++i;
+			}
+			else {
+				while (i < n && isDigitChar(format[i])) {
+					spec.precision.push_back(format[i++]);
+				}
+			}
+		}
+
+		while (i < n && isLengthChar(format[i])) {
+			++i;
+		}
+
+		if (i >= n) {
+			spec.end = n;
+			return spec;
+		}
+
+		spec.conv = format[i];
+		spec.end = i + 1;
+		spec.valid = isIntConv(spec.conv) || isFloatConv(spec.conv)
+			|| spec.conv == 's' || spec.conv == 'c';
+
+		return spec;
+	}
+
+	// Parses a numeric field, clamping to kMaxFieldWidth. Returns an empty string
+	// for anything unparseable or non-positive, which drops the field entirely.
+	std::string clampField(const std::string& digits)
+	{
+		if (digits.empty()) {
+			return std::string();
+		}
+
+		long value = 0;
+		for (size_t i = 0; i < digits.size(); ++i)
 		{
-			// Taranan metinde % karakteri var mý?
-			if (metin[index] == '%')
+			value = value * 10 + (digits[i] - '0');
+			if (value > kMaxFieldWidth) {
+				return std::to_string(kMaxFieldWidth);
+			}
+		}
+
+		return std::to_string(value);
+	}
+
+	// Rebuilds the specifier with any '*' already resolved to a literal number,
+	// so the value below is the only argument fmt has to bind.
+	std::string buildSpec(const Spec& spec, char conv)
+	{
+		std::string out("%");
+		out += spec.flags;
+		out += clampField(spec.width);
+
+		if (spec.has_precision) {
+			const std::string precision = clampField(spec.precision);
+			out += '.';
+			out += precision.empty() ? std::string("0") : precision;
+		}
+
+		out += conv;
+		return out;
+	}
+}
+
+std::string service::formattedString(AMX* amx, const cell* params, cell text_index, int args_offset)
+{
+	const std::string format = getString(amx, params[text_index]);
+
+	// Number of cells the script actually passed.
+	const int max_args = static_cast<int>(params[0] / sizeof(cell));
+
+	std::string out;
+	out.reserve(format.size() + 32);
+
+	const size_t n = format.size();
+	int arg = args_offset;
+	size_t i = 0;
+
+	while (i < n)
+	{
+		if (format[i] != '%') {
+			out.push_back(format[i++]);
+			continue;
+		}
+
+		// "%%" is a literal percent sign.
+		if (i + 1 < n && format[i + 1] == '%') {
+			out.push_back('%');
+			i += 2;
+			continue;
+		}
+
+		const Spec spec = parseSpec(format, i);
+
+		// A '*' width and a '*' precision each consume an argument of their own,
+		// on top of the value itself.
+		const int needed = 1
+			+ (spec.star_width ? 1 : 0)
+			+ (spec.star_precision ? 1 : 0);
+
+		// Anything unparseable, or not backed by enough arguments, is emitted
+		// exactly as it was written rather than scanned past.
+		if (!spec.valid || arg + needed - 1 > max_args) {
+			out.append(format, i, spec.end - i);
+			i = spec.end;
+			continue;
+		}
+
+		Spec resolved = spec;
+		bool failed = false;
+
+		if (resolved.star_width) {
+			cell* address = nullptr;
+			if (argAddress(amx, params, arg++, &address))
 			{
-				// Varsa index deðerini +1 olarak arttýr
-				index++;
-
-				// Taranan % karakteri var mý kontrol et, varsa karakteri % olarak ayarla ve bu indexi geç
-				if (metin[index] == '%')
+				// A negative '*' width means left-align by that many columns,
+				// which is the '-' flag plus a positive width.
+				int width = static_cast<int>(*address);
+				if (width < 0)
 				{
-					metin[index] = '%';
-					continue;
+					resolved.flags += '-';
+					width = (width == INT_MIN) ? kMaxFieldWidth : -width;
 				}
 
-				// Integer
-				if (metin[index] == 'd' || metin[index] == 'i' || metin[index] == 'o' || metin[index] == 'x' || metin[index] == 'X' || metin[index] == 'u')
-				{
-					int yuzde = index - 1;
+				resolved.width = std::to_string(width);
+			}
+			else {
+				failed = true;
+			}
+		}
 
-					cell* deger = nullptr;
-					amx_GetAddr(amx, params[args_count++], &deger);
-
-					metin.replace(yuzde, index - yuzde + 1, fmt::sprintf(metin.substr(yuzde, index - yuzde + 1), static_cast<int>(*deger)));
-				
-					continue;
+		if (!failed && resolved.star_precision) {
+			cell* address = nullptr;
+			if (argAddress(amx, params, arg++, &address))
+			{
+				// A negative '*' precision is specified to behave as if omitted.
+				const int precision = static_cast<int>(*address);
+				if (precision < 0) {
+					resolved.has_precision = false;
 				}
-
-				// Float
-				else if (metin[index] == 'f' || metin[index] == 'F' || metin[index] == 'a' || metin[index] == 'A' || metin[index] == 'g' || metin[index] == 'G')
-				{
-					int yuzde = index - 1;
-
-					cell* deger = nullptr;
-					amx_GetAddr(amx, params[args_count++], &deger);
-
-					metin.replace(yuzde, index - yuzde + 1, fmt::sprintf(metin.substr(yuzde, index - yuzde + 1), static_cast<float>(amx_ctof(*deger))));
-
-					continue;
+				else {
+					resolved.precision = std::to_string(precision);
 				}
+			}
+			else {
+				failed = true;
+			}
+		}
 
-				// String
-				else if (metin[index] == 's')
+		if (!failed)
+		{
+			// fmt throws on a specifier it cannot bind; a bad format string from a
+			// script must not be able to take the server down.
+			try
+			{
+				if (resolved.conv == 's')
 				{
-					int yuzde = index - 1;
-					metin.replace(yuzde, index - yuzde + 1, fmt::sprintf(metin.substr(yuzde, index - yuzde + 1), getString(amx, params[args_count++])));
-					continue;
+					out += fmt::sprintf(buildSpec(resolved, 's'), getString(amx, params[arg++]));
 				}
-
-				// Char
-				else if (metin[index] == 'c')
+				else if (resolved.conv == 'c')
 				{
-					bool degistir = false;
-
-					int yuzde = index - 1;
-
-					cell* deger = nullptr;
-					amx_GetAddr(amx, params[args_count++], &deger);
-
-					if (*deger == 0x25)
-					{
-						degistir = true;
-						metin.replace(yuzde, index - yuzde + 1, "%%");
+					cell* address = nullptr;
+					if (argAddress(amx, params, arg++, &address)) {
+						out += fmt::sprintf(buildSpec(resolved, 'c'), static_cast<char>(*address));
 					}
-					else
-					{
-						degistir = true;
-						metin.replace(yuzde, index - yuzde + 1, fmt::sprintf(metin.substr(yuzde, index - yuzde + 1), static_cast<char>(*deger)));
-					}
-
-					if (degistir)
-					{
-						continue;
+					else {
+						failed = true;
 					}
 				}
-
-				// %02d, %02f vs..
-				else if (metin[index] >= '0' && metin[index] <= '9')
+				else if (isFloatConv(resolved.conv))
 				{
-					bool degistir = false;
-
-					int yuzde = index - 1;
-
-					while (!isalpha(metin[index]))
-					{
-						index++;
+					cell* address = nullptr;
+					if (argAddress(amx, params, arg++, &address)) {
+						out += fmt::sprintf(buildSpec(resolved, resolved.conv),
+							static_cast<double>(amx_ctof(*address)));
 					}
-
-					if (metin[index] == 'd' || metin[index] == 'i' || metin[index] == 'o' || metin[index] == 'x' || metin[index] == 'X' || metin[index] == 'u')
-					{
-						cell* deger = nullptr;
-						amx_GetAddr(amx, params[args_count++], &deger);
-
-						metin.replace(yuzde, index - yuzde + 1, fmt::sprintf(metin.substr(yuzde, index - yuzde + 1), static_cast<int>(*deger)));
-					
-						degistir = true;
-					}
-					else if (metin[index] == 'f' || metin[index] == 'F' || metin[index] == 'a' || metin[index] == 'A' || metin[index] == 'g' || metin[index] == 'G')
-					{
-						cell* deger = nullptr;
-						amx_GetAddr(amx, params[args_count++], &deger);
-
-						metin.replace(yuzde, index - yuzde + 1, fmt::sprintf(metin.substr(yuzde, index - yuzde + 1), static_cast<float>(amx_ctof(*deger))));
-					
-						degistir = true;
-					}
-
-					if (degistir)
-					{
-						continue;
+					else {
+						failed = true;
 					}
 				}
-
-				// %.*s,  %.*f
-				else if (metin[index] == '.' && metin[index + 1] == '*')
+				else	// integer conversions
 				{
-					bool degistir = false;
-
-					int yuzde = index - 1;
-
-					while (!isalpha(metin[index]))
+					cell* address = nullptr;
+					if (argAddress(amx, params, arg++, &address))
 					{
-						index++;
+						if (resolved.conv == 'u' || resolved.conv == 'o'
+							|| resolved.conv == 'x' || resolved.conv == 'X')
+						{
+							out += fmt::sprintf(buildSpec(resolved, resolved.conv),
+								static_cast<unsigned int>(*address));
+						}
+						else
+						{
+							out += fmt::sprintf(buildSpec(resolved, resolved.conv),
+								static_cast<int>(*address));
+						}
 					}
-
-					if (metin[index] == 's')
-					{
-						degistir = true;
-
-						cell* deger = nullptr;
-						amx_GetAddr(amx, params[args_count++], &deger);
-
-						metin.replace(yuzde, index - yuzde + 1, fmt::sprintf(metin.substr(yuzde, index - yuzde + 1), static_cast<int>(*deger), getString(amx, params[args_count++])));
-					}
-
-					else if (metin[index] == 'f' || metin[index] == 'F' || metin[index] == 'a' || metin[index] == 'A' || metin[index] == 'g' || metin[index] == 'G')
-					{
-						degistir = true;
-
-						cell* deger = nullptr;
-						amx_GetAddr(amx, params[args_count++], &deger);
-
-						cell* deger2 = nullptr;
-						amx_GetAddr(amx, params[args_count++], &deger2);
-
-						metin.replace(yuzde, index - yuzde + 1, fmt::sprintf(metin.substr(yuzde, index - yuzde + 1), static_cast<int>(*deger), static_cast<float>(amx_ctof(*deger2))));
-					}
-
-					if (degistir)
-					{
-						continue;
-					}
-				}
-
-				// %.1s, %.1f
-				else if (metin[index] == '.' && metin[index + 1] != '*')
-				{
-					bool degistir = false;
-
-					int yuzde = index - 1;
-
-					while (!isalpha(metin[index]))
-					{
-						index++;
-					}
-
-					if (metin[index] == 's')
-					{
-						degistir = true;
-						metin.replace(yuzde, index - yuzde + 1, fmt::sprintf(metin.substr(yuzde, index - yuzde + 1), getString(amx, params[args_count++])));
-					}
-
-					else if (metin[index] == 'f' || metin[index] == 'F' || metin[index] == 'a' || metin[index] == 'A' || metin[index] == 'g' || metin[index] == 'G')
-					{
-						degistir = true;
-
-						cell* deger = nullptr;
-						amx_GetAddr(amx, params[args_count++], &deger);
-
-						metin.replace(yuzde, index - yuzde + 1, fmt::sprintf(metin.substr(yuzde, index - yuzde + 1), static_cast<float>(amx_ctof(*deger))));
-					}
-
-					if (degistir)
-					{
-						continue;
+					else {
+						failed = true;
 					}
 				}
 			}
-			index++;
+			catch (...)
+			{
+				failed = true;
+			}
 		}
+
+		if (failed) {
+			out.append(format, i, spec.end - i);
+		}
+
+		i = spec.end;
 	}
-	return metin.c_str();
+
+	return out;
 }

--- a/src/service.hpp
+++ b/src/service.hpp
@@ -14,15 +14,24 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <string>
-#include <sstream>
 #include "sampgdk.hpp"
 
 namespace service
 {
-	void setInt(AMX* amx, cell output, int value);
-	void setFloat(AMX* amx, cell output, float value);
-	void setString(AMX* amx, cell output, cell size, std::string string);
+	// Each of these returns false when the AMX address cannot be resolved,
+	// rather than writing through an unresolved pointer.
+	bool setInt(AMX* amx, cell output, int value);
+	bool setFloat(AMX* amx, cell output, float value);
+	bool setString(AMX* amx, cell output, cell size, const std::string& string);
+
+	// Returns an empty string when the address cannot be resolved.
 	std::string getString(AMX* amx, cell input);
-	std::string formattedString(AMX* amx, cell* params, cell text_index, int32_t args_offset);
+
+	// printf-style substitution of the AMX arguments starting at args_offset into
+	// the format string at text_index. A malformed format is emitted verbatim: it
+	// never reads past the end of the format or past params[params[0] / sizeof(cell)].
+	std::string formattedString(AMX* amx, const cell* params, cell text_index, int args_offset);
 };

--- a/src/slot_manager.cpp
+++ b/src/slot_manager.cpp
@@ -29,23 +29,23 @@
   */
 
 int slot_manager_global::next_Id;
-std::priority_queue<int, std::vector<int>, std::greater<int>> slot_manager_global::global_ids;
+IdHeap slot_manager_global::global_ids;
 
 int slot_manager_global::get_id()
 {
-	if (slot_manager_global::global_ids.empty()) {
-		return 1 + slot_manager_global::next_Id++;
+	if (global_ids.empty()) {
+		return 1 + next_Id++;
 	}
 
-	int low_id = slot_manager_global::global_ids.top();
-	slot_manager_global::global_ids.pop();
-	
+	const int low_id = global_ids.top();
+	global_ids.pop();
+
 	return low_id;
 }
 
 void slot_manager_global::remove_id(int value)
 {
-	slot_manager_global::global_ids.push(value);
+	global_ids.push(value);
 }
 
 
@@ -63,28 +63,40 @@ void slot_manager_global::remove_id(int value)
   *                             "Y88P"
   */
 
-std::map<int, int> slot_manager_player::next_Id;
-std::map<int, std::priority_queue<int, std::vector<int>, std::greater<int>>> slot_manager_player::p_Ids;
+std::array<int, MAX_PLAYERS> slot_manager_player::next_Id{};
+std::array<IdHeap, MAX_PLAYERS> slot_manager_player::p_Ids;
 
 int slot_manager_player::get_id(int playerid)
 {
-	if (slot_manager_player::p_Ids[playerid].empty()) {
-		return 1 + slot_manager_player::next_Id[playerid]++;
+	if (playerid < 0 || playerid >= MAX_PLAYERS) {
+		return 0;
 	}
 
-	int low_id = slot_manager_player::p_Ids[playerid].top();
-	slot_manager_player::p_Ids[playerid].pop();
+	if (p_Ids[playerid].empty()) {
+		return 1 + next_Id[playerid]++;
+	}
+
+	const int low_id = p_Ids[playerid].top();
+	p_Ids[playerid].pop();
 
 	return low_id;
 }
 
 void slot_manager_player::remove_id(int playerid, int value)
 {
-	slot_manager_player::p_Ids[playerid].push(value);
+	if (playerid < 0 || playerid >= MAX_PLAYERS) {
+		return;
+	}
+
+	p_Ids[playerid].push(value);
 }
 
 void slot_manager_player::reset_id(int playerid)
 {
-	slot_manager_player::next_Id[playerid] = 0;
-	slot_manager_player::p_Ids[playerid] = std::priority_queue<int, std::vector<int>, std::greater<int>>();
+	if (playerid < 0 || playerid >= MAX_PLAYERS) {
+		return;
+	}
+
+	next_Id[playerid] = 0;
+	p_Ids[playerid] = IdHeap();
 }

--- a/src/slot_manager.hpp
+++ b/src/slot_manager.hpp
@@ -16,27 +16,36 @@
 
 #pragma once
 
-#include <map>
+#include <array>
 #include <queue>
+#include <vector>
+
+#include "sampgdk.hpp"
+
+// Hands out the smallest free streamer id, so ids stay dense as textdraws are
+// created and destroyed.
+using IdHeap = std::priority_queue<int, std::vector<int>, std::greater<int>>;
 
 class slot_manager_player
 {
 public:
-	static int get_id(int playerid);
-	static void remove_id(int playerid, int value);
-	static void reset_id(int playerid);
+	// Returns 0 when playerid is out of range; ids otherwise start at 1.
+	static int	get_id(int playerid);
+	static void	remove_id(int playerid, int value);
+	static void	reset_id(int playerid);
 
 private:
-	static std::map<int, int> next_Id;
-	static std::map<int, std::priority_queue<int, std::vector<int>, std::greater<int>>> p_Ids;
+	static std::array<int, MAX_PLAYERS>		next_Id;
+	static std::array<IdHeap, MAX_PLAYERS>	p_Ids;
 };
 
 class slot_manager_global
 {
 public:
-	static int get_id();
-	static void remove_id(int value);
+	static int	get_id();
+	static void	remove_id(int value);
+
 private:
-	static int next_Id;
-	static std::priority_queue<int, std::vector<int>, std::greater<int>> global_ids;
+	static int		next_Id;
+	static IdHeap	global_ids;
 };

--- a/src/textdraw_data.cpp
+++ b/src/textdraw_data.cpp
@@ -16,8 +16,6 @@
 
 #include "textdraw_data.hpp"
 #include "slot_manager.hpp"
-#include "sampgdk.hpp"
-
 
  /***
   *     .d8888b.  888          888               888
@@ -29,113 +27,129 @@
   *    Y88b  d88P 888 Y88..88P 888 d88P 888  888 888
   *     "Y8888P88 888  "Y88P"  88888P"  "Y888888 888
   *
-  *
-  *
   */
 
-DefaultText GlobalText::Default;
+const Text_Data GlobalText::Default{};
 std::unordered_set<int> GlobalText::PlayerList;
-std::unordered_map<int, Text_Data*>* GlobalText::gText = new std::unordered_map<int, Text_Data*>();
-std::map<int, std::map<int, bool>> GlobalText::gTextVisible;
+TextMap GlobalText::gText;
+std::unordered_map<int, std::unordered_set<int>> GlobalText::gTextVisible;
+std::unordered_map<int, int> GlobalText::realToText;
+
+Text_Data* GlobalText::Find(int textid, const char* funcs)
+{
+	auto it = gText.find(textid);
+	if (it == gText.end())
+	{
+		Plugin_Settings::ILogger(LogType::FIND_GLOBAL_TEXT, funcs, INVALID_PLAYER_ID, textid);
+		return nullptr;
+	}
+
+	return &it->second;
+}
+
+void GlobalText::DestroyReal(Text_Data& data)
+{
+	if (data.real_id == INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		return;
+	}
+
+	TextDrawDestroy(data.real_id);
+	realToText.erase(data.real_id);
+	data.real_id = INVALID_DYNAMIC_PLAYER_TEXTDRAW;
+}
+
+bool GlobalText::Reload(int textid, Text_Data& data)
+{
+	if (data.real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		return true;
+	}
+
+	const int text_id = TextDrawCreate(data.create_x, data.create_y, data.text.c_str());
+
+	if (text_id == INVALID_TEXT_DRAW)
+	{
+		sampgdk::logprintf("[textdraw.streamer] GlobalText::Reload: A maximum of %d global textdraws can be created.", MAX_TEXT_DRAWS);
+		return false;
+	}
+
+	if (data.lettersize_x != Default.lettersize_x || data.lettersize_y != Default.lettersize_y) {
+		TextDrawLetterSize(text_id, data.lettersize_x, data.lettersize_y);
+	}
+
+	if (data.textsize_x != Default.textsize_x || data.textsize_y != Default.textsize_y) {
+		TextDrawTextSize(text_id, data.textsize_x, data.textsize_y);
+	}
+
+	if (data.alignment != Default.alignment) {
+		TextDrawAlignment(text_id, data.alignment);
+	}
+
+	if (data.color != Default.color) {
+		TextDrawColor(text_id, data.color);
+	}
+
+	if (data.usebox != Default.usebox) {
+		TextDrawUseBox(text_id, data.usebox);
+	}
+
+	if (data.boxcolor != Default.boxcolor) {
+		TextDrawBoxColor(text_id, data.boxcolor);
+	}
+
+	if (data.shadow != Default.shadow) {
+		TextDrawSetShadow(text_id, data.shadow);
+	}
+
+	if (data.outline != Default.outline) {
+		TextDrawSetOutline(text_id, data.outline);
+	}
+
+	if (data.backgroundcolor != Default.backgroundcolor) {
+		TextDrawBackgroundColor(text_id, data.backgroundcolor);
+	}
+
+	if (data.font != Default.font) {
+		TextDrawFont(text_id, data.font);
+	}
+
+	if (data.proportional != Default.proportional) {
+		TextDrawSetProportional(text_id, data.proportional);
+	}
+
+	if (data.selectable != Default.selectable) {
+		TextDrawSetSelectable(text_id, data.selectable);
+	}
+
+	if (data.font == TEXT_DRAW_FONT_MODEL_PREVIEW)
+	{
+		if (data.modelindex != Default.modelindex) {
+			TextDrawSetPreviewModel(text_id, data.modelindex);
+		}
+
+		if (data.fRotX != Default.fRotX || data.fRotY != Default.fRotY
+			|| data.fRotZ != Default.fRotZ || data.fZoom != Default.fZoom) {
+			TextDrawSetPreviewRot(text_id, data.fRotX, data.fRotY, data.fRotZ, data.fZoom);
+		}
+
+		if (data.veh_col1 != Default.veh_col1 || data.veh_col2 != Default.veh_col2) {
+			TextDrawSetPreviewVehCol(text_id, data.veh_col1, data.veh_col2);
+		}
+	}
+
+	data.real_id = text_id;
+	realToText[text_id] = textid;
+	return true;
+}
 
 void GlobalText::Destroy()
 {
-	if (!gText->empty())
-	{
-		for (auto it = gText->begin(); it != gText->end(); it++)
-		{
-			// Extra id
-			delete it->second->extra_id;
-			
-			// Array data
-			delete it->second->array_data;
-			
-			// Text data
-			delete it->second;
-		}
-
-		delete gText;
-		gText = nullptr;
+	for (auto& entry : gText) {
+		DestroyReal(entry.second);
 	}
-}
 
-void GlobalText::Reload(std::unordered_map<int, Text_Data*>::iterator it)
-{
-	if (it->second->real_id == INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		int text_id = TextDrawCreate(it->second->create_x, it->second->create_y, it->second->text.c_str());
-
-		if (text_id == INVALID_TEXT_DRAW)
-		{
-			sampgdk::logprintf("[textdraw.streamer] GlobalText::Reload: A maximum of %d global textdraws can be created.", MAX_TEXT_DRAWS);
-			return;
-		}
-
-		if (it->second->lettersize_x != GlobalText::Default.lettersize_x || it->second->lettersize_y != GlobalText::Default.lettersize_y) {
-			TextDrawLetterSize(text_id, it->second->lettersize_x, it->second->lettersize_y);
-		}
-
-		if (it->second->textsize_x != GlobalText::Default.textsize_x || it->second->textsize_y != GlobalText::Default.textsize_y) {
-			TextDrawTextSize(text_id, it->second->textsize_x, it->second->textsize_y);
-		}
-
-		if (it->second->alignment != GlobalText::Default.alignment) {
-			TextDrawAlignment(text_id, it->second->alignment);
-		}
-
-		if (it->second->color != GlobalText::Default.color) {
-			TextDrawColor(text_id, it->second->color);
-		}
-
-		if (it->second->usebox != GlobalText::Default.usebox) {
-			TextDrawUseBox(text_id, it->second->usebox);
-		}
-
-		if (it->second->boxcolor != GlobalText::Default.boxcolor) {
-			TextDrawBoxColor(text_id, it->second->boxcolor);
-		}
-
-		if (it->second->shadow != GlobalText::Default.shadow) {
-			TextDrawSetShadow(text_id, it->second->shadow);
-		}
-
-		if (it->second->outline != GlobalText::Default.outline) {
-			TextDrawSetOutline(text_id, it->second->outline);
-		}
-
-		if (it->second->backgroundcolor != GlobalText::Default.backgroundcolor) {
-			TextDrawBackgroundColor(text_id, it->second->backgroundcolor);
-		}
-
-		if (it->second->font != GlobalText::Default.font) {
-			TextDrawFont(text_id, it->second->font);
-		}
-
-		if (it->second->proportional != GlobalText::Default.proportional) {
-			TextDrawSetProportional(text_id, it->second->proportional);
-		}
-
-		if (it->second->selectable != GlobalText::Default.selectable) {
-			TextDrawSetSelectable(text_id, it->second->selectable);
-		}
-
-		if (it->second->font == TEXT_DRAW_FONT_MODEL_PREVIEW)
-		{
-			if (it->second->modelindex != GlobalText::Default.modelindex) {
-				TextDrawSetPreviewModel(text_id, it->second->modelindex);
-			}
-
-			if (it->second->fRotX != GlobalText::Default.fRotX || it->second->fRotY != GlobalText::Default.fRotY || it->second->fRotZ != GlobalText::Default.fRotZ || it->second->fZoom != GlobalText::Default.fZoom) {
-				TextDrawSetPreviewRot(text_id, it->second->fRotX, it->second->fRotY, it->second->fRotZ, it->second->fZoom);
-			}
-
-			if (it->second->veh_col1 != GlobalText::Default.veh_col1 || it->second->veh_col2 != GlobalText::Default.veh_col2) {
-				TextDrawSetPreviewVehCol( text_id, it->second->veh_col1, it->second->veh_col2);
-			}
-		}
-
-		it->second->real_id = text_id;
-	}
+	gText.clear();
+	gTextVisible.clear();
+	realToText.clear();
 }
 
  /***
@@ -152,142 +166,172 @@ void GlobalText::Reload(std::unordered_map<int, Text_Data*>::iterator it)
   *                             "Y88P"
   */
 
-DefaultText PlayerText::Default;
-std::unordered_map<int, std::unordered_map<int, Text_Data*>*> PlayerText::pText;
+const Text_Data PlayerText::Default{};
+std::array<TextMap*, MAX_PLAYERS> PlayerText::pText{};
+
+TextMap* PlayerText::Pool(int playerid)
+{
+	if (playerid < 0 || playerid >= MAX_PLAYERS) {
+		return nullptr;
+	}
+
+	return pText[playerid];
+}
+
+TextMap* PlayerText::Ensure(int playerid)
+{
+	if (playerid < 0 || playerid >= MAX_PLAYERS) {
+		return nullptr;
+	}
+
+	if (pText[playerid] == nullptr) {
+		pText[playerid] = new TextMap();
+	}
+
+	return pText[playerid];
+}
+
+Text_Data* PlayerText::Find(int playerid, int textid, const char* funcs)
+{
+	if (GlobalText::PlayerList.find(playerid) == GlobalText::PlayerList.end()) {
+		return nullptr;
+	}
+
+	TextMap* pool = Pool(playerid);
+	if (pool == nullptr)
+	{
+		Plugin_Settings::ILogger(LogType::CREATE_PLAYER_TEXTDRAW, funcs, playerid, textid);
+		return nullptr;
+	}
+
+	auto it = pool->find(textid);
+	if (it == pool->end())
+	{
+		Plugin_Settings::ILogger(LogType::FIND_PLAYER_TEXT, funcs, playerid, textid);
+		return nullptr;
+	}
+
+	return &it->second;
+}
+
+void PlayerText::DestroyReal(int playerid, Text_Data& data)
+{
+	if (data.real_id == INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		return;
+	}
+
+	PlayerTextDrawDestroy(playerid, data.real_id);
+	data.real_id = INVALID_DYNAMIC_PLAYER_TEXTDRAW;
+}
+
+bool PlayerText::Reload(int playerid, Text_Data& data)
+{
+	if (data.real_id != INVALID_DYNAMIC_PLAYER_TEXTDRAW) {
+		return true;
+	}
+
+	const int text_id = CreatePlayerTextDraw(playerid, data.create_x, data.create_y, data.text.c_str());
+
+	// Past MAX_PLAYER_TEXT_DRAWS this comes back invalid. Storing it would leave
+	// real_id at 0xFFFF, which passes every "!= INVALID" test from then on.
+	if (text_id == INVALID_TEXT_DRAW) {
+		return false;
+	}
+
+	if (data.lettersize_x != Default.lettersize_x || data.lettersize_y != Default.lettersize_y) {
+		PlayerTextDrawLetterSize(playerid, text_id, data.lettersize_x, data.lettersize_y);
+	}
+
+	if (data.textsize_x != Default.textsize_x || data.textsize_y != Default.textsize_y) {
+		PlayerTextDrawTextSize(playerid, text_id, data.textsize_x, data.textsize_y);
+	}
+
+	if (data.alignment != Default.alignment) {
+		PlayerTextDrawAlignment(playerid, text_id, data.alignment);
+	}
+
+	if (data.color != Default.color) {
+		PlayerTextDrawColor(playerid, text_id, data.color);
+	}
+
+	if (data.usebox != Default.usebox) {
+		PlayerTextDrawUseBox(playerid, text_id, data.usebox);
+	}
+
+	if (data.boxcolor != Default.boxcolor) {
+		PlayerTextDrawBoxColor(playerid, text_id, data.boxcolor);
+	}
+
+	if (data.shadow != Default.shadow) {
+		PlayerTextDrawSetShadow(playerid, text_id, data.shadow);
+	}
+
+	if (data.outline != Default.outline) {
+		PlayerTextDrawSetOutline(playerid, text_id, data.outline);
+	}
+
+	if (data.backgroundcolor != Default.backgroundcolor) {
+		PlayerTextDrawBackgroundColor(playerid, text_id, data.backgroundcolor);
+	}
+
+	if (data.font != Default.font) {
+		PlayerTextDrawFont(playerid, text_id, data.font);
+	}
+
+	if (data.proportional != Default.proportional) {
+		PlayerTextDrawSetProportional(playerid, text_id, data.proportional);
+	}
+
+	if (data.selectable != Default.selectable) {
+		PlayerTextDrawSetSelectable(playerid, text_id, data.selectable);
+	}
+
+	if (data.font == TEXT_DRAW_FONT_MODEL_PREVIEW)
+	{
+		if (data.modelindex != Default.modelindex) {
+			PlayerTextDrawSetPreviewModel(playerid, text_id, data.modelindex);
+		}
+
+		if (data.fRotX != Default.fRotX || data.fRotY != Default.fRotY
+			|| data.fRotZ != Default.fRotZ || data.fZoom != Default.fZoom) {
+			PlayerTextDrawSetPreviewRot(playerid, text_id, data.fRotX, data.fRotY, data.fRotZ, data.fZoom);
+		}
+
+		if (data.veh_col1 != Default.veh_col1 || data.veh_col2 != Default.veh_col2) {
+			PlayerTextDrawSetPreviewVehCol(playerid, text_id, data.veh_col1, data.veh_col2);
+		}
+	}
+
+	data.real_id = text_id;
+	return true;
+}
 
 void PlayerText::Destroy(int playerid)
 {
-	if (playerid >= 0 && playerid < MAX_PLAYERS)
+	TextMap* pool = Pool(playerid);
+	if (pool == nullptr) {
+		return;
+	}
+
+	// The client drops every player textdraw on disconnect, so the server-side
+	// ones do not need destroying individually here.
+	delete pool;
+	pText[playerid] = nullptr;
+
+	slot_manager_player::reset_id(playerid);
+}
+
+void PlayerText::DestroyAll()
+{
+	for (int playerid = 0; playerid < MAX_PLAYERS; ++playerid)
 	{
-		// Eger veri yoksa alt islemleri calistirma
 		if (pText[playerid] == nullptr) {
-			return;
+			continue;
 		}
 
-		// Sadece oyuncu kimliginin icerigini temizle
-		for (auto p = pText[playerid]->begin(); p != pText[playerid]->end(); p++)
-		{
-			// Extra id kaldir
-			delete p->second->extra_id;
-
-			// Array verilerini kaldir
-			delete p->second->array_data;
-
-			// Data daki verileri kaldir
-			delete p->second;
-		}
-
-		// Pointeri kaldir
 		delete pText[playerid];
 		pText[playerid] = nullptr;
 
-		// Slot manager da ki kimlikleri temizle
 		slot_manager_player::reset_id(playerid);
-	}
-	else
-	{
-		// playerid degeri -1 ve alti olursa tum oyuncu havuzunu temizle
-		for (auto it = pText.begin(); it != pText.end(); it++)
-		{
-			if (pText[it->first] == nullptr) {
-				continue;
-			}
-
-			for (auto p = pText[it->first]->begin(); p != pText[it->first]->end(); p++)
-			{
-				// Extra id kaldir
-				delete p->second->extra_id;
-
-				// Array verilerini kaldir
-				delete p->second->array_data;
-
-				// Data daki verileri kaldir
-				delete p->second;
-			}
-
-			// Pointeri kaldir
-			delete pText[it->first];
-			pText[playerid] = nullptr;
-
-			// Slot manager da ki kimlikleri temizle
-			slot_manager_player::reset_id(it->first);
-		}
-
-		// Tum pointer listesini temizle
-		pText.clear();
-	}
-}
-
-void PlayerText::Reload(int playerid, std::unordered_map<int, Text_Data*>::iterator it)
-{
-	if (it->second->real_id == INVALID_DYNAMIC_PLAYER_TEXTDRAW)
-	{
-		int text_id = CreatePlayerTextDraw(playerid, it->second->create_x, it->second->create_y, it->second->text.c_str());
-
-		if (it->second->lettersize_x != PlayerText::Default.lettersize_x || it->second->lettersize_y != PlayerText::Default.lettersize_y) {
-			PlayerTextDrawLetterSize(playerid, text_id, it->second->lettersize_x, it->second->lettersize_y);
-		}
-
-		if (it->second->textsize_x != PlayerText::Default.textsize_x || it->second->textsize_y != PlayerText::Default.textsize_y) {
-			PlayerTextDrawTextSize(playerid, text_id, it->second->textsize_x, it->second->textsize_y);
-		}
-
-		if (it->second->alignment != PlayerText::Default.alignment) {
-			PlayerTextDrawAlignment(playerid, text_id, it->second->alignment);
-		}
-
-		if (it->second->color != PlayerText::Default.color) {
-			PlayerTextDrawColor(playerid, text_id, it->second->color);
-		}
-
-		if (it->second->usebox != PlayerText::Default.usebox) {
-			PlayerTextDrawUseBox(playerid, text_id, it->second->usebox);
-		}
-
-		if (it->second->boxcolor != PlayerText::Default.boxcolor) {
-			PlayerTextDrawBoxColor(playerid, text_id, it->second->boxcolor);
-		}
-
-		if (it->second->shadow != PlayerText::Default.shadow) {
-			PlayerTextDrawSetShadow(playerid, text_id, it->second->shadow);
-		}
-
-		if (it->second->outline != PlayerText::Default.outline) {
-			PlayerTextDrawSetOutline(playerid, text_id, it->second->outline);
-		}
-
-		if (it->second->backgroundcolor != PlayerText::Default.backgroundcolor) {
-			PlayerTextDrawBackgroundColor(playerid, text_id, it->second->backgroundcolor);
-		}
-
-		if (it->second->font != PlayerText::Default.font) {
-			PlayerTextDrawFont(playerid, text_id, it->second->font);
-		}
-
-		if (it->second->proportional != PlayerText::Default.proportional) {
-			PlayerTextDrawSetProportional(playerid, text_id, it->second->proportional);
-		}
-
-		if (it->second->selectable != PlayerText::Default.selectable) {
-			PlayerTextDrawSetSelectable(playerid, text_id, it->second->selectable);
-		}
-
-		if (it->second->font == TEXT_DRAW_FONT_MODEL_PREVIEW)
-		{
-			if (it->second->modelindex != PlayerText::Default.modelindex) {
-				PlayerTextDrawSetPreviewModel(playerid, text_id, it->second->modelindex);
-			}
-
-			if (it->second->fRotX != PlayerText::Default.fRotX || it->second->fRotY != PlayerText::Default.fRotY || it->second->fRotZ != PlayerText::Default.fRotZ || it->second->fZoom != PlayerText::Default.fZoom) {
-				PlayerTextDrawSetPreviewRot(playerid, text_id, it->second->fRotX, it->second->fRotY, it->second->fRotZ, it->second->fZoom);
-			}
-
-			if (it->second->veh_col1 != PlayerText::Default.veh_col1 || it->second->veh_col2 != PlayerText::Default.veh_col2) {
-				PlayerTextDrawSetPreviewVehCol(playerid, text_id, it->second->veh_col1, it->second->veh_col2);
-			}
-		}
-
-		it->second->real_id = text_id;
-		PlayerTextDrawShow(playerid, it->second->real_id);
 	}
 }

--- a/src/textdraw_data.hpp
+++ b/src/textdraw_data.hpp
@@ -16,11 +16,14 @@
 
 #pragma once
 
-#include <iostream>
+#include <array>
 #include <map>
-#include <vector>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
+
+#include "sampgdk.hpp"
 
 #define	INVALID_DYNAMIC_PLAYER_TEXTDRAW	(-1)
 
@@ -39,93 +42,128 @@ enum LogType
 
 	// Global
 	FIND_GLOBAL_TEXT,
+	SHOW_LIMIT_GLOBAL,
 
 	// Data
 	INVALID_TYPE,
 };
 
-struct DefaultText
-{
-	float		lettersize_x	= 0.0;
-	float		lettersize_y	= 0.0;
-	float		textsize_x		= 0.0;
-	float		textsize_y		= 0.0;
-	int			alignment		= 1;
-	int			color			= -2;
-	int			usebox			= 0;
-	int			boxcolor		= -2;
-	int			shadow			= 2;
-	int			outline			= 0;
-	int			backgroundcolor	= -2;
-	int			font			= 1;
-	int			proportional	= 1;
-	int			selectable		= 0;
-	int			modelindex		= 0;
-	float		fRotX			= 0.0;
-	float		fRotY			= 0.0;
-	float		fRotZ			= 0.0;
-	float		fZoom			= 1.0;
-	int			veh_col1		= -2;
-	int			veh_col2		= -2;
-};
-
+// The member initializers below are the single source of truth for a new
+// textdraw's state. A default-constructed Text_Data doubles as the baseline that
+// Reload compares against to skip setter calls that would be no-ops.
 struct Text_Data
 {
-	int					real_id{};
-	float				create_x{};
-	float				create_y{};
+	int					real_id			= INVALID_DYNAMIC_PLAYER_TEXTDRAW;
+	float				create_x		= 0.0f;
+	float				create_y		= 0.0f;
 	std::string			text;
-	float				lettersize_x{};
-	float				lettersize_y{};
-	float				textsize_x{};
-	float				textsize_y{};
-	int					alignment{};
-	int					color{};
-	int					usebox{};
-	int					boxcolor{};
-	int					shadow{};
-	int					outline{};
-	int					backgroundcolor{};
-	int					font{};
-	int					proportional{};
-	int					selectable{};
-	int					modelindex{};
-	float				fRotX{};
-	float				fRotY{};
-	float				fRotZ{};
-	float				fZoom{};
-	int					veh_col1{};
-	int					veh_col2{};
-	std::map<int, int>* extra_id{};
-	float				float_data{};
-	std::vector<int>*	array_data{};
+	float				lettersize_x	= 0.0f;
+	float				lettersize_y	= 0.0f;
+	float				textsize_x		= 0.0f;
+	float				textsize_y		= 0.0f;
+	int					alignment		= 1;
+	int					color			= -2;
+	int					usebox			= 0;
+	int					boxcolor		= -2;
+	int					shadow			= 2;
+	int					outline			= 0;
+	int					backgroundcolor	= -2;
+	int					font			= 1;
+	int					proportional	= 1;
+	int					selectable		= 0;
+	int					modelindex		= 0;
+	float				fRotX			= 0.0f;
+	float				fRotY			= 0.0f;
+	float				fRotZ			= 0.0f;
+	float				fZoom			= 1.0f;
+	int					veh_col1		= -2;
+	int					veh_col2		= -2;
+
+	// Whether the script currently wants this on screen. Distinct from real_id,
+	// which only says whether a server-side textdraw is presently allocated.
+	bool				visible			= false;
+
+	// Script-attached data. Held by value: an empty map and vector cost no
+	// allocation, and the great majority of textdraws never touch either.
+	float				float_data		= 0.0f;
+	std::map<int, int>	extra_id;
+	std::vector<int>	array_data;
 };
+
+// Node-based, so a Text_Data* handed out by Find stays valid across later
+// inserts into the same container.
+using TextMap = std::unordered_map<int, Text_Data>;
 
 class Plugin_Settings
 {
 public:
-	static bool logMode;
-	static std::string file;
-	static int line;
-	static void ILogger(LogType type, std::string funcs, int playerid, int textid);
+	static bool	logMode;
+
+	// The __file/__line the include macros pass in. The string is not read out of
+	// the AMX unless a message is actually logged, which is the uncommon path.
+	static AMX*	amx;
+	static cell	fileParam;
+	static int	line;
+
+	static void SetContext(AMX* source, cell file, cell lineNumber)
+	{
+		amx = source;
+		fileParam = file;
+		line = static_cast<int>(lineNumber);
+	}
+
+	// Called when an AMX unloads so a later log can never resolve a stale pointer.
+	static void ClearContext(AMX* source)
+	{
+		if (amx == source) {
+			amx = nullptr;
+		}
+	}
+
+	static void ILogger(LogType type, const char* funcs, int playerid, int textid);
 };
 
 class PlayerText
 {
 public:
-	static DefaultText Default;
-	static std::unordered_map<int, std::unordered_map<int, Text_Data*>*> pText;
-	static void Destroy(int playerid);
-	static void Reload(int playerid, std::unordered_map<int, Text_Data*>::iterator it);
+	static const Text_Data					Default;
+	static std::array<TextMap*, MAX_PLAYERS>	pText;
+
+	// The player's textdraw pool, or nullptr if out of range or none created yet.
+	static TextMap*		Pool(int playerid);
+
+	// Pool(), creating it on first use.
+	static TextMap*		Ensure(int playerid);
+
+	// Full guard sequence with the same logging the natives used inline.
+	// Returns nullptr and logs when the player or the textdraw is not found.
+	static Text_Data*	Find(int playerid, int textid, const char* funcs);
+
+	// Creates the server-side textdraw and applies every non-default property.
+	// Does not show it; that is the caller's decision. False means the per-player
+	// limit was reached, and real_id is left INVALID.
+	static bool			Reload(int playerid, Text_Data& data);
+
+	// Destroys the server-side textdraw if one exists and invalidates real_id.
+	static void			DestroyReal(int playerid, Text_Data& data);
+
+	static void			Destroy(int playerid);
+	static void			DestroyAll();
 };
 
 class GlobalText
 {
 public:
-	static DefaultText Default;
-	static std::unordered_set<int> PlayerList;
-	static std::unordered_map<int, Text_Data*>* gText;
-	static std::map<int, std::map<int, bool>> gTextVisible;
-	static void Destroy();
-	static void Reload(std::unordered_map<int, Text_Data*>::iterator it);
+	static const Text_Data									Default;
+	static std::unordered_set<int>							PlayerList;
+	static TextMap											gText;
+	static std::unordered_map<int, std::unordered_set<int>>	gTextVisible;
+
+	// real_id -> textid, so a textdraw click resolves without scanning gText.
+	static std::unordered_map<int, int>						realToText;
+
+	static Text_Data*	Find(int textid, const char* funcs);
+	static bool			Reload(int textid, Text_Data& data);
+	static void			DestroyReal(Text_Data& data);
+	static void			Destroy();
 };


### PR DESCRIPTION
## Summary

`DynPlayerTextDrawGetTextSize` wrote `textsize_x` into both out-parameters, so
callers got width where they asked for height. The global twin was already
correct, which identified it as a copy-paste slip.

Auditing for the same class of defect surfaced ~30 further issues, including two
that crash the server and a script-reachable format parser that reads past the
end of its buffer. Net: **-1,000 lines** across 14 files.

The Pawn API is unchanged — no `.inc` edits, no native renames, no signature
changes. Existing gamemodes work without recompiling.

## Crashes

- **Null dereference (8 sites, `natives_data.cpp`).** `pText[playerid]->find(...)`
  with no null check. `unordered_map::operator[]` inserts a null pointer for an
  absent key, then dereferences it. One line of Pawn crashed the server for any
  player who hadn't yet created a player textdraw:
  `DynamicTextDraw_GetIntData(DYNAMIC_TEXTDRAW_TYPE_PLAYER, 1, 0, playerid)`.
  The other ~40 player natives all guarded this.

- **Iterator invalidation (`textdraw_data.cpp`).** The clear-all branch inserted
  key `-1` into the map it was iterating; the rehash could invalidate the
  iterator mid-loop. Fired on `Unload`.

## Correctness

- `PlayerText::Reload` never checked `CreatePlayerTextDraw` against
  `INVALID_TEXT_DRAW`. Past the 256/player limit it stored `real_id = 65535`,
  which passes the `!= -1` validity test forever — permanently wedging the
  textdraw.
- `DynamicTextDrawSetPos` re-showed to every connected player rather than to the
  players who could actually see it. Now re-shows only to `gTextVisible[textid]`
  (identical when shown via `ShowForAll`).
- `DynamicPlayerTextDrawSetPos` re-showed even when hidden.
- Unguarded `TextDrawDestroy(-1)` when hiding a never-shown textdraw.
- `DestroyDynamicTextDraw` leaked one container per textdraw ever created.
- `%%` never collapsed to a single `%`.
- `formattedString` returned `.c_str()` from a `std::string`, truncating at
  embedded NULs.
- `setInt`/`setFloat` wrote through an uninitialized pointer when
  `amx_GetAddr` failed.

## Memory safety in the format parser

Reachable with script-controlled format strings via `CreateDynamicTextDraw` /
`SetString`:

- `while (!isalpha(fmt[i])) i++;` walked off the end of the buffer for inputs
  like `"%1"` or `"%."` — OOB read, potential hang.
- No bound on `params[]`, so `"%d %d"` with one argument read past the parameter
  array and treated garbage as an AMX address.
- `isalpha` called with negative values (UB; this codebase handles non-ASCII).

Rewritten as a bounded single pass with explicit spec parsing. Malformed specs
are emitted verbatim. Adds a `try/catch` around `fmt::sprintf` and an 8192-column
field cap so `"%999999999d"` can't force a huge allocation.

## Performance

- **No allocation per native call.** All ~90 natives opened by building a
  `std::string` for a log location that is almost never printed. Now three
  stores, resolved lazily only when a message is emitted.
- **3 allocations per textdraw → 1.** `extra_id` / `array_data` held by value;
  removes every manual `delete`.
- `map<int, map<int,bool>>` → `unordered_map<int, unordered_set<int>>` for
  viewers (~48 KB of tree nodes per textdraw at 1000 players).
- O(n) click scan over 2048 entries → O(1) via a `real_id -> textid` index.
- `std::map` keyed by playerid → flat arrays.

## Build

- `cmake_minimum_required(2.8)` hard-errors on CMake 4 — raised to 3.10.
- Linux builds now happen in a `debian:11` container (glibc 2.31). Building on
  current distros produced a `.so` requiring `GLIBC_2.38` (isoc23 symbol
  redirects) and then `GLIBC_2.34` (libpthread merged into libc), which failed
  to load on real game hosts.
- CI asserts the max `GLIBC_` requirement via `objdump -T` and fails the build
  above the baseline, so this can't silently regress.
- Adds 32-bit CI for Linux and Windows plus a tag-triggered release job.
